### PR TITLE
fix: Lambda ReservedConcurrentExecutions 제거 (계정 동시실행 한도 초과 방지)

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -112,7 +112,6 @@ Resources:
       Handler: app.job_detail_crawler
       Timeout: 60
       MemorySize: 256
-      ReservedConcurrentExecutions: 10
       Policies:
         - S3CrudPolicy:
             BucketName: !Ref CrawlerDataBucket


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> close #5

## #️⃣ 작업 내용

> `template.yaml`에서 `JobDetailCrawler` Lambda의 `ReservedConcurrentExecutions: 10` 설정을 제거했습니다.
> AWS 계정의 Lambda 동시 실행 한도가 10인 상태에서 해당 설정이 unreserved를 0으로 만들어 배포가 실패했습니다.

## #️⃣ 테스트 결과

> GitHub Actions의 `sam deploy`가 `ReservedConcurrentExecutions` 관련 에러 없이 정상 배포되는지 확인 필요.

## #️⃣ 변경 사항 체크리스트

- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?