### PR TITLE
feat: 크롤링 데이터 품질 개선 및 임베딩 모델 전환 (#9)

### DIFF
--- a/consumer/Dockerfile
+++ b/consumer/Dockerfile
@@ -5,8 +5,8 @@ WORKDIR /app
 COPY consumer/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-# 한국어 임베딩 모델 사전 다운로드 (콜드스타트 방지)
-RUN python -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('jhgan/ko-sroberta-multitask')"
+# 임베딩 모델 사전 다운로드 (콜드스타트 방지)
+RUN python -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('BAAI/bge-m3')"
 
 # 공유 모듈 복사
 COPY src/storage/chromadb.py ./storage/chromadb.py

--- a/src/parser/jobkorea.py
+++ b/src/parser/jobkorea.py
@@ -64,17 +64,71 @@ def parse_job_detail(html: str) -> JobkoreaMetadata:
 
 
 def parse_job_iframe(html: str) -> str | None:
-    """iframe 에서 JD 텍스트 전체를 추출. 이미지 JD 면 None."""
+    """iframe 에서 JD 텍스트를 추출하고 노이즈 섹션을 제거. 이미지 JD 면 None."""
     soup = BeautifulSoup(html, "html.parser")
     text = soup.get_text(separator="\n", strip=True)
 
     if len(text) < IMAGE_JD_TEXT_THRESHOLD and soup.find_all("img"):
         return None
 
-    return text or None
+    if not text:
+        return None
+
+    cleaned = _remove_noise_sections(text)
+    return cleaned or None
 
 
 # ── 내부 헬퍼 ──
+
+
+# JD 본문 시작을 나타내는 키워드.
+# iframe 상단의 기업소개 노이즈를 건너뛰기 위해 사용한다.
+_JD_START_HEADERS: frozenset[str] = frozenset({
+    "모집분야", "모집부문", "모집공고",
+    "담당업무", "주요업무", "업무내용", "주요직무",
+    "자격요건", "지원자격", "필수요건",
+    "우대사항", "우대요건",
+})
+
+# 노이즈 섹션 시작 키워드. 해당 줄부터 끝까지 제거한다.
+# 잡코리아 iframe 하단에 복리후생·전형절차·접수정보가 반복적으로 붙는 패턴.
+_NOISE_SECTION_HEADERS: frozenset[str] = frozenset({
+    # 복리후생 블록
+    "복리후생",
+    # 전형·접수 블록
+    "전형절차", "채용절차",
+    "제출서류",
+    "접수기간 및 방법", "접수기간", "접수방법",
+    # 기업 소개 블록
+    "기업정보", "기업 개요",
+})
+
+
+def _remove_noise_sections(text: str) -> str:
+    """기업소개·복리후생·전형절차 등 노이즈 섹션을 제거.
+
+    1) JD 본문 시작 키워드(모집분야/담당업무 등)를 찾아 그 앞의 상단 노이즈를 제거한다.
+    2) 노이즈 섹션 키워드(복리후생/전형절차 등)를 찾아 그 뒤의 하단 노이즈를 제거한다.
+    두 전략을 결합하여 JD 본문 영역만 남긴다.
+    """
+    lines = text.split("\n")
+
+    # 상단 노이즈 제거: JD 시작 키워드가 나올 때까지 건너뛰기
+    start_index = 0
+    for i, line in enumerate(lines):
+        if line.strip() in _JD_START_HEADERS:
+            start_index = i
+            break
+
+    # 하단 노이즈 제거: JD 본문 이후 노이즈 헤더부터 끝까지 잘라내기
+    end_index = len(lines)
+    for i in range(start_index, len(lines)):
+        if lines[i].strip() in _NOISE_SECTION_HEADERS:
+            end_index = i
+            break
+
+    result = "\n".join(lines[start_index:end_index]).strip()
+    return result
 
 
 def _match_escaped_json_string(html: str, key: str) -> str:
@@ -85,7 +139,11 @@ def _match_escaped_json_string(html: str, key: str) -> str:
 
 
 def _extract_tech_stack(html: str) -> list[str]:
-    """__next_f 에서 HARD_SKILL 기술스택을 추출·정규화·중복 제거."""
+    """__next_f 에서 HARD_SKILL 기술스택을 추출·정규화·중복 제거.
+
+    잡코리아가 자격증·어학·비기술 항목도 HARD_SKILL 로 분류하므로
+    패턴 매칭으로 제외한다.
+    """
     normalized: list[str] = []
     seen: set[str] = set()
 
@@ -99,6 +157,8 @@ def _extract_tech_stack(html: str) -> list[str]:
         name = match.group(1)
         if not name or len(name) >= 30:
             continue
+        if _is_non_tech_skill(name):
+            continue
         canonical = normalize_tech_name(name)
         key = canonical.lower()
         if key not in seen:
@@ -106,3 +166,28 @@ def _extract_tech_stack(html: str) -> list[str]:
             normalized.append(canonical)
 
     return normalized
+
+
+# 자격증 패턴: "~기사 자격", "~기능사 자격", "~관리사 자격" 등
+_CERT_PATTERN = re.compile(
+    r"(기사|기능사|관리사|산업기사)\s*자격$"
+)
+
+# 어학·비기술 항목 (소문자 비교)
+_NON_TECH_NAMES: frozenset[str] = frozenset({
+    # 어학
+    "영어", "일본어", "중국어", "한국어",
+    "비즈니스영어", "비즈니스일본어", "비즈니스중국어",
+    "toeic", "toefl", "teps", "opic", "jlpt", "hsk",
+    # 비기술
+    "운전면허", "컴퓨터활용능력", "워드",
+    "한글", "한셀", "한쇼",
+    "powerpoint", "excel", "microsoft office",
+})
+
+
+def _is_non_tech_skill(name: str) -> bool:
+    """자격증·어학·비기술 항목이면 True."""
+    if _CERT_PATTERN.search(name):
+        return True
+    return name.lower().strip() in _NON_TECH_NAMES

--- a/src/parser/jobkorea.py
+++ b/src/parser/jobkorea.py
@@ -188,6 +188,7 @@ _NON_TECH_NAMES: frozenset[str] = frozenset({
 
 def _is_non_tech_skill(name: str) -> bool:
     """자격증·어학·비기술 항목이면 True."""
-    if _CERT_PATTERN.search(name):
+    cleaned = name.strip()
+    if _CERT_PATTERN.search(cleaned):
         return True
-    return name.lower().strip() in _NON_TECH_NAMES
+    return cleaned.lower() in _NON_TECH_NAMES

--- a/src/storage/chromadb.py
+++ b/src/storage/chromadb.py
@@ -9,7 +9,7 @@ from crawler.base import JobDetail
 
 logger = logging.getLogger(__name__)
 
-EMBEDDING_MODEL = "jhgan/ko-sroberta-multitask"
+EMBEDDING_MODEL = "BAAI/bge-m3"
 _URL_FETCH_CHUNK = 1000
 
 

--- a/tests/unit/test_parser_jobkorea.py
+++ b/tests/unit/test_parser_jobkorea.py
@@ -1,0 +1,223 @@
+"""parser.jobkorea 단위 테스트 — tech_stack 필터링 및 raw_text 노이즈 제거."""
+from parser.jobkorea import (
+    _extract_tech_stack,
+    _is_non_tech_skill,
+    _remove_noise_sections,
+    parse_job_iframe,
+)
+
+
+class TestIsNonTechSkill:
+    """자격증·어학·비기술 항목 판별."""
+
+    def test_certification_patterns(self):
+        assert _is_non_tech_skill("정보처리기사 자격")
+        assert _is_non_tech_skill("정보처리기능사 자격")
+        assert _is_non_tech_skill("공조냉동기계기사 자격")
+        assert _is_non_tech_skill("토목기사 자격")
+        assert _is_non_tech_skill("정보통신산업기사 자격")
+
+    def test_language_skills(self):
+        assert _is_non_tech_skill("영어")
+        assert _is_non_tech_skill("비즈니스영어")
+        assert _is_non_tech_skill("일본어")
+        assert _is_non_tech_skill("TOEIC")
+        assert _is_non_tech_skill("toeic")
+        assert _is_non_tech_skill("JLPT")
+
+    def test_non_tech_items(self):
+        assert _is_non_tech_skill("운전면허")
+        assert _is_non_tech_skill("컴퓨터활용능력")
+        assert _is_non_tech_skill("워드")
+        assert _is_non_tech_skill("Excel")
+        assert _is_non_tech_skill("PowerPoint")
+        assert _is_non_tech_skill("Microsoft Office")
+
+    def test_real_tech_not_filtered(self):
+        assert not _is_non_tech_skill("Python")
+        assert not _is_non_tech_skill("JAVA")
+        assert not _is_non_tech_skill("Docker")
+        assert not _is_non_tech_skill("kubernetes")
+        assert not _is_non_tech_skill("React")
+        assert not _is_non_tech_skill("Spring Boot")
+        assert not _is_non_tech_skill("PostgreSQL")
+        assert not _is_non_tech_skill("Linux")
+
+
+class TestExtractTechStack:
+    """_extract_tech_stack 에서 비기술 항목이 제외되는지 검증."""
+
+    @staticmethod
+    def _make_skill_html(name: str) -> str:
+        return (
+            f'\\"name\\":\\"{name}\\"'
+            f',\\"rank\\":0'
+            f',\\"manualInput\\":false'
+            f',\\"skillTypeCode\\":\\"HARD_SKILL\\"'
+        )
+
+    def test_filters_certification(self):
+        html = self._make_skill_html("정보처리기사 자격")
+        result = _extract_tech_stack(html)
+        assert result == []
+
+    def test_filters_language(self):
+        html = self._make_skill_html("TOEIC")
+        result = _extract_tech_stack(html)
+        assert result == []
+
+    def test_keeps_real_tech(self):
+        html = self._make_skill_html("Python")
+        result = _extract_tech_stack(html)
+        assert result == ["Python"]
+
+    def test_mixed_skills(self):
+        skills = ["JAVA", "영어", "Docker", "정보처리기사 자격", "React"]
+        html = " ".join(self._make_skill_html(s) for s in skills)
+        result = _extract_tech_stack(html)
+        assert result == ["Java", "Docker", "React"]
+
+
+class TestRemoveNoiseSections:
+    """복리후생·전형절차 등 노이즈 섹션 제거."""
+
+    def test_removes_benefits_section(self):
+        text = (
+            "담당업무\n"
+            "백엔드 서버 개발\n"
+            "자격요건\n"
+            "Python 3년 이상\n"
+            "복리후생\n"
+            "4대 보험\n"
+            "명절선물\n"
+        )
+        result = _remove_noise_sections(text)
+        assert "백엔드 서버 개발" in result
+        assert "Python 3년 이상" in result
+        assert "복리후생" not in result
+        assert "4대 보험" not in result
+
+    def test_removes_process_section(self):
+        text = (
+            "담당업무\n"
+            "서비스 개발\n"
+            "전형절차\n"
+            "서류전형\n"
+            "면접\n"
+        )
+        result = _remove_noise_sections(text)
+        assert "서비스 개발" in result
+        assert "전형절차" not in result
+        assert "서류전형" not in result
+
+    def test_removes_application_info(self):
+        text = (
+            "우대사항\n"
+            "AWS 경험\n"
+            "접수기간 및 방법\n"
+            "채용 시 마감\n"
+        )
+        result = _remove_noise_sections(text)
+        assert "AWS 경험" in result
+        assert "접수기간" not in result
+
+    def test_no_noise_returns_original(self):
+        text = "담당업무\n서비스 개발\n자격요건\nPython"
+        result = _remove_noise_sections(text)
+        assert result == text
+
+    def test_empty_after_noise_removal(self):
+        text = "복리후생\n4대 보험"
+        result = _remove_noise_sections(text)
+        assert result == ""
+
+    def test_first_noise_header_wins(self):
+        text = (
+            "담당업무\n"
+            "개발\n"
+            "복리후생\n"
+            "보험\n"
+            "전형절차\n"
+            "면접\n"
+        )
+        result = _remove_noise_sections(text)
+        assert "개발" in result
+        assert "복리후생" not in result
+        assert "전형절차" not in result
+
+    def test_removes_top_noise_before_jd_start(self):
+        text = (
+            "기업 개요\n"
+            "업력 9년차\n"
+            "대기업\n"
+            "모집분야\n"
+            "백엔드 개발자\n"
+            "자격요건\n"
+            "Python 3년\n"
+        )
+        result = _remove_noise_sections(text)
+        assert "기업 개요" not in result
+        assert "업력 9년차" not in result
+        assert "모집분야" in result
+        assert "Python 3년" in result
+
+    def test_removes_both_top_and_bottom_noise(self):
+        text = (
+            "회사명\n"
+            "설립일 2015년\n"
+            "담당업무\n"
+            "서버 개발\n"
+            "자격요건\n"
+            "Java 경험\n"
+            "복리후생\n"
+            "4대 보험\n"
+            "전형절차\n"
+            "면접\n"
+        )
+        result = _remove_noise_sections(text)
+        assert "회사명" not in result
+        assert "설립일" not in result
+        assert "담당업무" in result
+        assert "서버 개발" in result
+        assert "Java 경험" in result
+        assert "복리후생" not in result
+
+    def test_no_jd_marker_keeps_from_beginning(self):
+        text = (
+            "백엔드 개발자 모집\n"
+            "Python 경험 필수\n"
+            "복리후생\n"
+            "4대 보험\n"
+        )
+        result = _remove_noise_sections(text)
+        assert "백엔드 개발자 모집" in result
+        assert "Python 경험 필수" in result
+        assert "복리후생" not in result
+
+
+class TestParseJobIframe:
+    """parse_job_iframe 통합 검증."""
+
+    def test_noise_removed_from_output(self):
+        html = (
+            "<html><body>"
+            "<p>담당업무</p><p>백엔드 개발</p>"
+            "<p>자격요건</p><p>Python 경험</p>"
+            "<p>복리후생</p><p>4대 보험</p><p>점심 제공</p>"
+            "</body></html>"
+        )
+        result = parse_job_iframe(html)
+        assert result is not None
+        assert "백엔드 개발" in result
+        assert "복리후생" not in result
+        assert "4대 보험" not in result
+
+    def test_image_jd_returns_none(self):
+        html = '<html><body><img src="jd.png"><p>짧음</p></body></html>'
+        result = parse_job_iframe(html)
+        assert result is None
+
+    def test_empty_text_returns_none(self):
+        html = "<html><body></body></html>"
+        result = parse_job_iframe(html)
+        assert result is None


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #9

## #️⃣ 작업 내용

### 1. tech_stack 비기술 항목 필터링
- `_is_non_tech_skill` 함수 추가: 자격증(`~기사/기능사 자격`), 어학(`영어`, `TOEIC` 등), 비기술(`운전면허`, `Excel` 등)을 `_extract_tech_stack`에서 제외
- 자격증은 정규식 패턴(`_CERT_PATTERN`), 어학/비기술은 이름 집합(`_NON_TECH_NAMES`)으로 판별

### 2. raw_text 노이즈 제거
- `_remove_noise_sections` 함수 추가
- 상단 노이즈: JD 시작 키워드(`모집분야`, `담당업무` 등) 앞의 기업소개 등 제거
- 하단 노이즈: `복리후생`, `전형절차`, `접수기간` 등 키워드 이후 제거

### 3. 임베딩 모델 전환
- `jhgan/ko-sroberta-multitask` (128토큰, 768차원) → `BAAI/bge-m3` (8,192토큰, 1024차원)
- 기존 모델은 `max_seq_length=128`로 JD 텍스트(228~2,328토큰) 대부분이 잘려 유사도 검색 품질 저하
- 차원 변경(768→1024)으로 기존 ChromaDB 컬렉션 재생성 필요 (개발 단계라 영향 없음)

## #️⃣ 테스트 결과

- 파서 단위 테스트 20개 신규 작성, 전체 37개 테스트 통과
  - `TestIsNonTechSkill` (4건): 자격증/어학/비기술 판별 + 실제 기술스택 통과 확인
  - `TestExtractTechStack` (4건): 필터링 후 정규화 결과 검증
  - `TestRemoveNoiseSections` (8건): 상단/하단/양쪽 노이즈 제거 + 엣지 케이스
  - `TestParseJobIframe` (3건): 통합 검증
- 스모크 테스트(`local_smoke.py`)로 실제 잡코리아 크롤링 결과 확인 완료

## #️⃣ 변경 사항 체크리스트

- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [x] 문서를 작성하거나 수정했나요? (필요한 경우)
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## #️⃣ 리뷰 요구사항 (선택)

- `_NON_TECH_NAMES` 집합과 `_NOISE_SECTION_HEADERS` 키워드가 충분한지 확인 부탁드립니다
- 임베딩 모델 전환 후 AI 서버도 동일하게 `BAAI/bge-m3`로 변경 필요합니다

## 📎 참고 자료 (선택)

- BAAI/bge-m3: https://huggingface.co/BAAI/bge-m3
- 다국어 임베딩, 한국어 포함 100+개 언어 지원, max 8,192 토큰, 1024차원, MIT 라이선스