### PR TITLE
feat: 임베딩 모델 경량화 — KR-SBERT ONNX 양자화 + 문단 청킹 (#14)

### DIFF
--- a/consumer/Dockerfile
+++ b/consumer/Dockerfile
@@ -1,3 +1,28 @@
+# Stage 1: ONNX 모델 변환 및 양자화
+FROM python:3.11-slim AS builder
+
+RUN pip install --no-cache-dir torch --index-url https://download.pytorch.org/whl/cpu
+RUN pip install --no-cache-dir "optimum[onnxruntime]" transformers
+
+# KR-SBERT → ONNX 변환
+RUN optimum-cli export onnx \
+    --model snunlp/KR-SBERT-V40K-klueNLI-augSTS \
+    /tmp/onnx_model/ \
+    --task feature-extraction
+
+# 동적 양자화 (~440MB → ~110MB)
+RUN python -c "\
+from onnxruntime.quantization import quantize_dynamic, QuantType; \
+quantize_dynamic('/tmp/onnx_model/model.onnx', '/tmp/kr-sbert-uint8.onnx', weight_type=QuantType.QUInt8)"
+
+# 토크나이저만 별도 저장
+RUN python -c "\
+from transformers import AutoTokenizer; \
+t = AutoTokenizer.from_pretrained('snunlp/KR-SBERT-V40K-klueNLI-augSTS'); \
+t.save_pretrained('/tmp/tokenizer/')"
+
+
+# Stage 2: 경량 런타임
 FROM python:3.11-slim
 
 WORKDIR /app
@@ -5,8 +30,9 @@ WORKDIR /app
 COPY consumer/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-# 임베딩 모델 사전 다운로드 (콜드스타트 방지)
-RUN python -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('BAAI/bge-m3')"
+# 양자화 모델 + 토크나이저만 복사 (~110MB)
+COPY --from=builder /tmp/kr-sbert-uint8.onnx /app/models/kr-sbert-uint8.onnx
+COPY --from=builder /tmp/tokenizer/ /app/models/tokenizer/
 
 # 공유 모듈 복사
 COPY src/storage/chromadb.py ./storage/chromadb.py

--- a/consumer/requirements.txt
+++ b/consumer/requirements.txt
@@ -1,3 +1,5 @@
 chromadb-client
 boto3
-sentence-transformers
+onnxruntime
+transformers
+numpy

--- a/src/storage/chromadb.py
+++ b/src/storage/chromadb.py
@@ -1,23 +1,118 @@
-"""ChromaDB HTTP 클라이언트. JD 를 raw text 로 저장하고 URL 기준 중복 제거."""
+"""ChromaDB HTTP 클라이언트. ONNX 양자화 임베딩으로 JD 를 저장하고 URL 기준 중복 제거."""
 import logging
+import os
 from collections.abc import Iterable
 
 import chromadb
-from chromadb.utils.embedding_functions import SentenceTransformerEmbeddingFunction
 
 from crawler.base import JobDetail
 
 logger = logging.getLogger(__name__)
 
-EMBEDDING_MODEL = "BAAI/bge-m3"
+EMBEDDING_MODEL = "snunlp/KR-SBERT-V40K-klueNLI-augSTS"
+_MODEL_DIR = os.environ.get("EMBEDDING_MODEL_DIR", "/app/models")
+_ONNX_MODEL_PATH = os.path.join(_MODEL_DIR, "kr-sbert-uint8.onnx")
+_TOKENIZER_PATH = os.path.join(_MODEL_DIR, "tokenizer")
+_MAX_CHUNK_TOKENS = 510  # 512 - [CLS] - [SEP]
 _URL_FETCH_CHUNK = 1000
+
+
+class OnnxEmbeddingFunction:
+    """ONNX 양자화 모델 + 문단 청킹 임베딩 함수. ChromaDB embedding_function 프로토콜 준수."""
+
+    def __init__(
+        self,
+        model_path: str = _ONNX_MODEL_PATH,
+        tokenizer_path: str = _TOKENIZER_PATH,
+    ):
+        import numpy as np
+        import onnxruntime as ort
+        from transformers import AutoTokenizer
+
+        self._np = np
+        self.tokenizer = AutoTokenizer.from_pretrained(tokenizer_path)
+        self.session = ort.InferenceSession(
+            model_path, providers=["CPUExecutionProvider"],
+        )
+        self._input_names = {inp.name for inp in self.session.get_inputs()}
+        logger.info("ONNX 임베딩 로드 완료: %s", model_path)
+
+    def __call__(self, input: list[str]) -> list[list[float]]:
+        np = self._np
+        results = []
+
+        for text in input:
+            chunks = self._chunk_by_paragraphs(text)
+            encoded = self.tokenizer(
+                chunks, return_tensors="np", padding=True,
+                truncation=True, max_length=512,
+            )
+
+            ort_inputs = {
+                name: encoded[name]
+                for name in self._input_names
+                if name in encoded
+            }
+            outputs = self.session.run(None, ort_inputs)
+            token_embeddings = outputs[0]
+
+            attention_mask = encoded["attention_mask"]
+            mask_expanded = np.expand_dims(attention_mask, axis=-1)
+            sum_embeddings = np.sum(token_embeddings * mask_expanded, axis=1)
+            sum_mask = np.clip(np.sum(mask_expanded, axis=1), a_min=1e-9, a_max=None)
+            chunk_embeddings = sum_embeddings / sum_mask
+
+            token_counts = np.sum(attention_mask, axis=1)
+            weights = token_counts / np.sum(token_counts)
+            weighted_embedding = np.sum(
+                chunk_embeddings * weights[:, np.newaxis], axis=0,
+            )
+
+            norm = max(float(np.linalg.norm(weighted_embedding)), 1e-9)
+            results.append((weighted_embedding / norm).tolist())
+
+        return results
+
+    def _chunk_by_paragraphs(self, text: str) -> list[str]:
+        """문단 단위로 텍스트를 분할. 각 chunk 가 _MAX_CHUNK_TOKENS 를 넘지 않도록 그룹핑."""
+        paragraphs = [p.strip() for p in text.split("\n") if p.strip()]
+        if not paragraphs:
+            return [text or " "]
+
+        chunks: list[str] = []
+        current_lines: list[str] = []
+        current_tokens = 0
+
+        for para in paragraphs:
+            para_tokens = len(self.tokenizer.encode(para, add_special_tokens=False))
+
+            if para_tokens > _MAX_CHUNK_TOKENS:
+                if current_lines:
+                    chunks.append("\n".join(current_lines))
+                    current_lines = []
+                    current_tokens = 0
+                chunks.append(para)
+                continue
+
+            if current_tokens + para_tokens > _MAX_CHUNK_TOKENS and current_lines:
+                chunks.append("\n".join(current_lines))
+                current_lines = []
+                current_tokens = 0
+
+            current_lines.append(para)
+            current_tokens += para_tokens
+
+        if current_lines:
+            chunks.append("\n".join(current_lines))
+
+        return chunks or [text or " "]
 
 
 class ChromaDBStorage:
 
     def __init__(self, host: str, port: int, collection_name: str = "job_descriptions"):
         self.client = chromadb.HttpClient(host=host, port=port)
-        embedding_fn = SentenceTransformerEmbeddingFunction(model_name=EMBEDDING_MODEL)
+        embedding_fn = OnnxEmbeddingFunction()
         self.collection = self.client.get_or_create_collection(
             name=collection_name,
             embedding_function=embedding_fn,


### PR DESCRIPTION
## #️⃣ 연관된 이슈

closes #14

## #️⃣ 작업 내용

### 문제 상황

EC2 t3.micro(1GB RAM)에서 기존 임베딩 모델(`BAAI/bge-m3`, 2.2GB)이 OOM을 일으켜 Consumer가 정상 동작하지 못했다.

```
RuntimeError: unable to mmap 2271145830 bytes: Cannot allocate memory (12)
```

ChromaDB에 컬렉션이 생성되지 않았고, 크롤링된 JD가 벡터 DB에 저장되지 않는 상태였다.

### 해결 전략

프리티어(t3.micro) 환경을 유지하면서 임베딩 파이프라인을 정상화하기 위해 세 가지를 적용했다.

#### 1. 임베딩 모델 교체

| 항목 | 변경 전 (bge-m3) | 변경 후 (KR-SBERT) |
|------|-----------------|-------------------|
| 모델 | `BAAI/bge-m3` | `snunlp/KR-SBERT-V40K-klueNLI-augSTS` |
| 원본 크기 | 2.2GB | ~440MB |
| 벡터 차원 | 1024 | 768 |
| max 토큰 | 8,192 | 512 |
| 한국어 | 다국어 지원 | 한국어 특화 |

#### 2. ONNX 동적 양자화 (QUInt8)

모델 가중치를 float32 → uint8로 양자화하여 크기를 추가로 줄였다.

- ~440MB → **~110MB** (약 75% 감소)
- 런타임 메모리: **~300MB** (t3.micro 1GB 내 여유)
- PyTorch 없이 `onnxruntime`만으로 추론 → 런타임 의존성 경량화

Dockerfile을 **멀티스테이지 빌드**로 구성하여, PyTorch + optimum은 빌드 단계에서만 사용하고 최종 이미지에는 포함하지 않는다.

```
Stage 1 (builder): PyTorch + optimum → ONNX 변환 → 양자화
Stage 2 (runtime): onnxruntime + transformers + 양자화 모델(~110MB)만 포함
```

#### 3. 문단 단위 청킹 + 토큰 수 가중 평균

KR-SBERT의 max 512토큰 제한으로 JD 텍스트(보통 1,000~3,000토큰)가 잘리는 문제를 해결했다.

**청킹 방식**: 토큰 단위로 기계적으로 자르지 않고, `\n` 기준 문단 경계를 존중하며 510토큰(512 - [CLS] - [SEP]) 이내로 그룹핑한다.

```
[주요업무]                        ─┐
- 백엔드 API 설계 및 개발          │ chunk 1 (480토큰)
- MSA 기반 서비스 운영             ─┘

[자격요건]                        ─┐
- CS 전공 또는 동등 경력           │ chunk 2 (510토큰)
- Python, Java 3년 이상           ─┘

[우대사항]                        ─┐
- AWS 경험                        │ chunk 3 (120토큰)
- 오픈소스 기여 경험               ─┘
```

**가중 평균**: 각 chunk의 임베딩을 토큰 수 기준으로 가중 평균한다. 마지막에 짧게 남은 chunk가 과대 반영되지 않도록 한다.

```
가중치 = 각 chunk의 토큰 수 / 전체 토큰 수
최종 벡터 = Σ(chunk 임베딩 × 가중치) → L2 정규화
```

이 방식으로 512토큰 제한 모델이면서도 JD 전체 내용을 빠짐없이 임베딩에 반영한다.

### 변경 파일

| 파일 | 변경 내용 |
|------|----------|
| `src/storage/chromadb.py` | `SentenceTransformerEmbeddingFunction` → `OnnxEmbeddingFunction` (ONNX 추론 + 문단 청킹 + mean pooling + 가중 평균 + L2 정규화). ChromaDB 프로토콜 준수를 위해 `name()` 메서드 추가. ONNX 의존성은 지연 import로 처리하여 Lambda/테스트 환경에서 import 에러 방지 |
| `consumer/Dockerfile` | 멀티스테이지 빌드. Stage 1에서 KR-SBERT를 ONNX 변환 + 양자화, Stage 2에 양자화 모델(~110MB) + 토크나이저만 포함 |
| `consumer/requirements.txt` | `sentence-transformers` 제거 → `onnxruntime`, `transformers`, `numpy` 추가 |

### 예상 메모리 (t3.micro)

| 컨테이너 | 메모리 |
|----------|--------|
| ChromaDB | ~13MB |
| Consumer + KR-SBERT 양자화 | ~250MB |
| **합계** | **~260MB** (1GB 내 여유 충분) |

## #️⃣ 테스트 결과

기존 단위 테스트 37개 모두 통과.

```
tests/unit/test_handler.py         — 12 passed
tests/unit/test_consumer.py        — 5 passed
tests/unit/test_parser_jobkorea.py — 16 passed
tests/unit/test_s3_storage.py      — 4 passed
======================== 37 passed in 0.65s =========================
```

- `OnnxEmbeddingFunction`의 ONNX 의존성을 지연 import로 처리하여, onnxruntime이 없는 로컬/Lambda 환경에서도 `storage.chromadb` 모듈 import가 정상 동작
- Consumer 테스트는 `ChromaDBStorage`를 mock하므로 ONNX 모델 없이 통과

## #️⃣ 변경 사항 체크리스트

- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [x] 문서를 작성하거나 수정했나요? (필요한 경우)
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## #️⃣ 리뷰 요구사항 (선택)

- `OnnxEmbeddingFunction._chunk_by_paragraphs`: 문단 그룹핑 로직이 엣지 케이스(빈 텍스트, 단일 문단이 510토큰 초과)를 올바르게 처리하는지 확인 부탁드립니다.
- Dockerfile 멀티스테이지 빌드에서 `optimum-cli export onnx`가 KR-SBERT 모델에 정상 동작하는지, CI 빌드 시간이 합리적인지 확인이 필요합니다.

## 📎 참고 자료 (선택)

- [ONNX 양자화를 통한 임베딩 모델 경량화 (블로그)](https://uiandwe.tistory.com/92190)
- [snunlp/KR-SBERT-V40K-klueNLI-augSTS (HuggingFace)](https://huggingface.co/snunlp/KR-SBERT-V40K-klueNLI-augSTS)