### PR TITLE
feat: 임베딩 계산을 Lambda로 이전하여 EC2 메모리 안정화 (#17)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,5 +46,6 @@ jobs:
             --no-fail-on-empty-changeset \
             --capabilities CAPABILITY_IAM \
             --resolve-s3 \
+            --resolve-image-repos \
             --parameter-overrides \
               S3BucketName=${{ secrets.S3_BUCKET_NAME }}

--- a/consumer/Dockerfile
+++ b/consumer/Dockerfile
@@ -1,38 +1,9 @@
-# Stage 1: ONNX 모델 변환 및 양자화
-FROM python:3.11-slim AS builder
-
-RUN pip install --no-cache-dir torch --index-url https://download.pytorch.org/whl/cpu
-RUN pip install --no-cache-dir "optimum[onnxruntime]" transformers
-
-# KR-SBERT → ONNX 변환
-RUN optimum-cli export onnx \
-    --model snunlp/KR-SBERT-V40K-klueNLI-augSTS \
-    /tmp/onnx_model/ \
-    --task feature-extraction
-
-# 동적 양자화 (~440MB → ~110MB)
-RUN python -c "\
-from onnxruntime.quantization import quantize_dynamic, QuantType; \
-quantize_dynamic('/tmp/onnx_model/model.onnx', '/tmp/kr-sbert-uint8.onnx', weight_type=QuantType.QUInt8)"
-
-# 토크나이저만 별도 저장
-RUN python -c "\
-from transformers import AutoTokenizer; \
-t = AutoTokenizer.from_pretrained('snunlp/KR-SBERT-V40K-klueNLI-augSTS'); \
-t.save_pretrained('/tmp/tokenizer/')"
-
-
-# Stage 2: 경량 런타임
 FROM python:3.11-slim
 
 WORKDIR /app
 
 COPY consumer/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
-
-# 양자화 모델 + 토크나이저만 복사 (~110MB)
-COPY --from=builder /tmp/kr-sbert-uint8.onnx /app/models/kr-sbert-uint8.onnx
-COPY --from=builder /tmp/tokenizer/ /app/models/tokenizer/
 
 # 공유 모듈 복사
 COPY src/storage/chromadb.py ./storage/chromadb.py

--- a/consumer/consumer.py
+++ b/consumer/consumer.py
@@ -57,7 +57,8 @@ def process_parsed_files(s3, bucket: str, storage: ChromaDBStorage) -> int:
                     crawled_at=data["crawled_at"],
                 )
 
-                storage.save(detail)
+                embedding = data.get("embedding")
+                storage.save(detail, embedding=embedding)
                 s3.delete_object(Bucket=bucket, Key=key)
                 saved += 1
             except Exception:

--- a/consumer/requirements.txt
+++ b/consumer/requirements.txt
@@ -1,5 +1,2 @@
 chromadb-client
 boto3
-onnxruntime
-transformers
-numpy

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,0 +1,39 @@
+# Stage 1: ONNX 모델 변환 및 양자화
+FROM python:3.11-slim AS builder
+
+RUN pip install --no-cache-dir torch --index-url https://download.pytorch.org/whl/cpu
+RUN pip install --no-cache-dir "optimum[onnxruntime]" transformers
+
+# KR-SBERT → ONNX 변환
+RUN optimum-cli export onnx \
+    --model snunlp/KR-SBERT-V40K-klueNLI-augSTS \
+    /tmp/onnx_model/ \
+    --task feature-extraction
+
+# 동적 양자화 (~440MB → ~110MB)
+RUN python -c "\
+from onnxruntime.quantization import quantize_dynamic, QuantType; \
+quantize_dynamic('/tmp/onnx_model/model.onnx', '/tmp/kr-sbert-uint8.onnx', weight_type=QuantType.QUInt8)"
+
+# 토크나이저만 별도 저장
+RUN python -c "\
+from transformers import AutoTokenizer; \
+t = AutoTokenizer.from_pretrained('snunlp/KR-SBERT-V40K-klueNLI-augSTS'); \
+t.save_pretrained('/tmp/tokenizer/')"
+
+
+# Stage 2: Lambda 런타임
+FROM public.ecr.aws/lambda/python:3.11
+
+# 양자화 모델 + 토크나이저 복사
+COPY --from=builder /tmp/kr-sbert-uint8.onnx /app/models/kr-sbert-uint8.onnx
+COPY --from=builder /tmp/tokenizer/ /app/models/tokenizer/
+
+# 의존성 설치
+COPY src/requirements.txt ${LAMBDA_TASK_ROOT}/
+RUN pip install --no-cache-dir -r ${LAMBDA_TASK_ROOT}/requirements.txt
+
+# 소스 코드 복사
+COPY src/ ${LAMBDA_TASK_ROOT}/
+
+CMD ["app.job_detail_crawler"]

--- a/src/app.py
+++ b/src/app.py
@@ -11,6 +11,7 @@ import boto3
 
 from crawler.base import JobDetail, JobListingRef
 from crawler.registry import get_crawler, iter_sources
+from embedding import build_document, embed_text
 from storage.s3 import S3Storage
 
 logger = logging.getLogger(__name__)
@@ -117,7 +118,10 @@ def job_detail_crawler(event, context):
             if detail is None:
                 logger.info("텍스트 JD 없음, 스킵: id=%s", ref.external_id)
                 continue
-            storage.save(detail)
+
+            document = build_document(detail.raw_text, detail.tech_stack)
+            embedding = embed_text(document)
+            storage.save(detail, embedding=embedding)
         except Exception:
             logger.exception("상세 크롤링 실패: id=%s", ref.external_id)
             raise

--- a/src/embedding.py
+++ b/src/embedding.py
@@ -1,0 +1,116 @@
+"""ONNX 양자화 임베딩 모듈. Lambda 에서 JD 임베딩을 계산하고 S3 에 저장할 때 사용."""
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+EMBEDDING_MODEL = "snunlp/KR-SBERT-V40K-klueNLI-augSTS"
+_MODEL_DIR = os.environ.get("EMBEDDING_MODEL_DIR", "/app/models")
+_ONNX_MODEL_PATH = os.path.join(_MODEL_DIR, "kr-sbert-uint8.onnx")
+_TOKENIZER_PATH = os.path.join(_MODEL_DIR, "tokenizer")
+_MAX_CHUNK_TOKENS = 510  # 512 - [CLS] - [SEP]
+
+_session = None
+_tokenizer = None
+_input_names = None
+_np = None
+
+
+def _load_model():
+    """ONNX 모델과 토크나이저를 1회 로딩. Lambda 웜 스타트 시 재사용."""
+    global _session, _tokenizer, _input_names, _np
+
+    if _session is not None:
+        return
+
+    import numpy as np
+    import onnxruntime as ort
+    from transformers import AutoTokenizer
+
+    _np = np
+    _tokenizer = AutoTokenizer.from_pretrained(_TOKENIZER_PATH)
+    _session = ort.InferenceSession(
+        _ONNX_MODEL_PATH, providers=["CPUExecutionProvider"],
+    )
+    _input_names = {inp.name for inp in _session.get_inputs()}
+    logger.info("ONNX 임베딩 로드 완료: %s", _ONNX_MODEL_PATH)
+
+
+def _chunk_by_paragraphs(text: str) -> list[str]:
+    """문단 단위로 텍스트를 분할. 각 chunk 가 _MAX_CHUNK_TOKENS 를 넘지 않도록 그룹핑."""
+    paragraphs = [p.strip() for p in text.split("\n") if p.strip()]
+    if not paragraphs:
+        return [text or " "]
+
+    chunks: list[str] = []
+    current_lines: list[str] = []
+    current_tokens = 0
+
+    for para in paragraphs:
+        para_tokens = len(_tokenizer.encode(para, add_special_tokens=False))
+
+        if para_tokens > _MAX_CHUNK_TOKENS:
+            if current_lines:
+                chunks.append("\n".join(current_lines))
+                current_lines = []
+                current_tokens = 0
+            chunks.append(para)
+            continue
+
+        if current_tokens + para_tokens > _MAX_CHUNK_TOKENS and current_lines:
+            chunks.append("\n".join(current_lines))
+            current_lines = []
+            current_tokens = 0
+
+        current_lines.append(para)
+        current_tokens += para_tokens
+
+    if current_lines:
+        chunks.append("\n".join(current_lines))
+
+    return chunks or [text or " "]
+
+
+def embed_text(text: str) -> list[float]:
+    """텍스트를 문단 청킹 + 토큰 수 가중 평균 임베딩으로 변환."""
+    _load_model()
+    np = _np
+
+    chunks = _chunk_by_paragraphs(text)
+    encoded = _tokenizer(
+        chunks, return_tensors="np", padding=True,
+        truncation=True, max_length=512,
+    )
+
+    ort_inputs = {
+        name: encoded[name]
+        for name in _input_names
+        if name in encoded
+    }
+    outputs = _session.run(None, ort_inputs)
+    token_embeddings = outputs[0]
+
+    attention_mask = encoded["attention_mask"]
+    mask_expanded = np.expand_dims(attention_mask, axis=-1)
+    sum_embeddings = np.sum(token_embeddings * mask_expanded, axis=1)
+    sum_mask = np.clip(np.sum(mask_expanded, axis=1), a_min=1e-9, a_max=None)
+    chunk_embeddings = sum_embeddings / sum_mask
+
+    token_counts = np.sum(attention_mask, axis=1)
+    weights = token_counts / np.sum(token_counts)
+    weighted_embedding = np.sum(
+        chunk_embeddings * weights[:, np.newaxis], axis=0,
+    )
+
+    norm = max(float(np.linalg.norm(weighted_embedding)), 1e-9)
+    return (weighted_embedding / norm).tolist()
+
+
+def build_document(raw_text: str, tech_stack: tuple[str, ...]) -> str:
+    """raw_text + tech_stack 을 임베딩 대상 document 문자열로 조합."""
+    parts: list[str] = []
+    if raw_text:
+        parts.append(raw_text)
+    if tech_stack:
+        parts.append(f"[기술스택]\n{', '.join(tech_stack)}")
+    return "\n\n".join(parts)

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,2 +1,5 @@
 requests
 beautifulsoup4
+onnxruntime
+transformers
+numpy

--- a/src/storage/chromadb.py
+++ b/src/storage/chromadb.py
@@ -1,6 +1,5 @@
-"""ChromaDB HTTP 클라이언트. ONNX 양자화 임베딩으로 JD 를 저장하고 URL 기준 중복 제거."""
+"""ChromaDB HTTP 클라이언트. 사전 계산된 임베딩으로 JD 를 저장하고 URL 기준 중복 제거."""
 import logging
-import os
 from collections.abc import Iterable
 
 import chromadb
@@ -9,121 +8,19 @@ from crawler.base import JobDetail
 
 logger = logging.getLogger(__name__)
 
-EMBEDDING_MODEL = "snunlp/KR-SBERT-V40K-klueNLI-augSTS"
-_MODEL_DIR = os.environ.get("EMBEDDING_MODEL_DIR", "/app/models")
-_ONNX_MODEL_PATH = os.path.join(_MODEL_DIR, "kr-sbert-uint8.onnx")
-_TOKENIZER_PATH = os.path.join(_MODEL_DIR, "tokenizer")
-_MAX_CHUNK_TOKENS = 510  # 512 - [CLS] - [SEP]
 _URL_FETCH_CHUNK = 1000
-
-
-class OnnxEmbeddingFunction:
-    """ONNX 양자화 모델 + 문단 청킹 임베딩 함수. ChromaDB embedding_function 프로토콜 준수."""
-
-    def __init__(
-        self,
-        model_path: str = _ONNX_MODEL_PATH,
-        tokenizer_path: str = _TOKENIZER_PATH,
-    ):
-        import numpy as np
-        import onnxruntime as ort
-        from transformers import AutoTokenizer
-
-        self._np = np
-        self.tokenizer = AutoTokenizer.from_pretrained(tokenizer_path)
-        self.session = ort.InferenceSession(
-            model_path, providers=["CPUExecutionProvider"],
-        )
-        self._input_names = {inp.name for inp in self.session.get_inputs()}
-        logger.info("ONNX 임베딩 로드 완료: %s", model_path)
-
-    @staticmethod
-    def name() -> str:
-        return "onnx_kr_sbert"
-
-    def __call__(self, input: list[str]) -> list[list[float]]:
-        np = self._np
-        results = []
-
-        for text in input:
-            chunks = self._chunk_by_paragraphs(text)
-            encoded = self.tokenizer(
-                chunks, return_tensors="np", padding=True,
-                truncation=True, max_length=512,
-            )
-
-            ort_inputs = {
-                name: encoded[name]
-                for name in self._input_names
-                if name in encoded
-            }
-            outputs = self.session.run(None, ort_inputs)
-            token_embeddings = outputs[0]
-
-            attention_mask = encoded["attention_mask"]
-            mask_expanded = np.expand_dims(attention_mask, axis=-1)
-            sum_embeddings = np.sum(token_embeddings * mask_expanded, axis=1)
-            sum_mask = np.clip(np.sum(mask_expanded, axis=1), a_min=1e-9, a_max=None)
-            chunk_embeddings = sum_embeddings / sum_mask
-
-            token_counts = np.sum(attention_mask, axis=1)
-            weights = token_counts / np.sum(token_counts)
-            weighted_embedding = np.sum(
-                chunk_embeddings * weights[:, np.newaxis], axis=0,
-            )
-
-            norm = max(float(np.linalg.norm(weighted_embedding)), 1e-9)
-            results.append((weighted_embedding / norm).tolist())
-
-        return results
-
-    def _chunk_by_paragraphs(self, text: str) -> list[str]:
-        """문단 단위로 텍스트를 분할. 각 chunk 가 _MAX_CHUNK_TOKENS 를 넘지 않도록 그룹핑."""
-        paragraphs = [p.strip() for p in text.split("\n") if p.strip()]
-        if not paragraphs:
-            return [text or " "]
-
-        chunks: list[str] = []
-        current_lines: list[str] = []
-        current_tokens = 0
-
-        for para in paragraphs:
-            para_tokens = len(self.tokenizer.encode(para, add_special_tokens=False))
-
-            if para_tokens > _MAX_CHUNK_TOKENS:
-                if current_lines:
-                    chunks.append("\n".join(current_lines))
-                    current_lines = []
-                    current_tokens = 0
-                chunks.append(para)
-                continue
-
-            if current_tokens + para_tokens > _MAX_CHUNK_TOKENS and current_lines:
-                chunks.append("\n".join(current_lines))
-                current_lines = []
-                current_tokens = 0
-
-            current_lines.append(para)
-            current_tokens += para_tokens
-
-        if current_lines:
-            chunks.append("\n".join(current_lines))
-
-        return chunks or [text or " "]
 
 
 class ChromaDBStorage:
 
     def __init__(self, host: str, port: int, collection_name: str = "job_descriptions"):
         self.client = chromadb.HttpClient(host=host, port=port)
-        embedding_fn = OnnxEmbeddingFunction()
         self.collection = self.client.get_or_create_collection(
             name=collection_name,
-            embedding_function=embedding_fn,
         )
 
-    def save(self, detail: JobDetail) -> None:
-        """raw_text + tech_stack 을 document 로, 나머지를 metadata 로 저장."""
+    def save(self, detail: JobDetail, *, embedding: list[float] | None = None) -> None:
+        """사전 계산된 embedding 과 document/metadata 를 ChromaDB 에 저장."""
         parts: list[str] = []
         if detail.raw_text:
             parts.append(detail.raw_text)
@@ -135,10 +32,10 @@ class ChromaDBStorage:
             logger.warning("저장할 텍스트 없음: %s", detail.url)
             return
 
-        self.collection.upsert(
-            ids=[detail.url],
-            documents=[document],
-            metadatas=[{
+        upsert_kwargs: dict = {
+            "ids": [detail.url],
+            "documents": [document],
+            "metadatas": [{
                 "source": detail.source,
                 "external_id": detail.external_id,
                 "company_name": detail.company_name,
@@ -148,7 +45,11 @@ class ChromaDBStorage:
                 "crawled_at": detail.crawled_at,
                 "tech_stack": _tech_stack_to_str(detail.tech_stack),
             }],
-        )
+        }
+        if embedding is not None:
+            upsert_kwargs["embeddings"] = [embedding]
+
+        self.collection.upsert(**upsert_kwargs)
         logger.info("저장 완료: %s - %s", detail.company_name, detail.title)
 
     def delete_expired(self, now_iso: str) -> int:

--- a/src/storage/s3.py
+++ b/src/storage/s3.py
@@ -31,10 +31,10 @@ class S3Storage:
                 return set()
             raise
 
-    def save(self, detail: JobDetail) -> None:
+    def save(self, detail: JobDetail, *, embedding: list[float] | None = None) -> None:
         """크롤링 결과를 parsed/{source}/{external_id}.json 으로 S3 에 저장."""
         key = f"parsed/{detail.source}/{detail.external_id}.json"
-        body = json.dumps({
+        data = {
             "source": detail.source,
             "external_id": detail.external_id,
             "url": detail.url,
@@ -44,7 +44,10 @@ class S3Storage:
             "tech_stack": list(detail.tech_stack),
             "deadline": detail.deadline,
             "crawled_at": detail.crawled_at,
-        }, ensure_ascii=False)
+        }
+        if embedding is not None:
+            data["embedding"] = embedding
+        body = json.dumps(data, ensure_ascii=False)
 
         self.s3.put_object(Bucket=self.bucket, Key=key, Body=body.encode("utf-8"))
         logger.info("S3 저장 완료: %s", key)

--- a/template.yaml
+++ b/template.yaml
@@ -103,15 +103,14 @@ Resources:
       AlarmActions:
         - !Ref DLQAlarmTopic
 
-  # ── Lambda 2: 상세 크롤러 ──
+  # ── Lambda 2: 상세 크롤러 + 임베딩 (컨테이너 이미지) ──
   JobDetailCrawler:
     Type: AWS::Serverless::Function
     Properties:
       FunctionName: passroute-job-detail-crawler
-      CodeUri: src/
-      Handler: app.job_detail_crawler
-      Timeout: 60
-      MemorySize: 256
+      PackageType: Image
+      Timeout: 120
+      MemorySize: 512
       Policies:
         - S3CrudPolicy:
             BucketName: !Ref CrawlerDataBucket
@@ -121,6 +120,10 @@ Resources:
           Properties:
             Queue: !GetAtt JobDetailQueue.Arn
             BatchSize: 1
+    Metadata:
+      DockerTag: python3.11
+      DockerContext: .
+      Dockerfile: src/Dockerfile
 
 Outputs:
   JobListCollectorArn:

--- a/tests/unit/test_handler.py
+++ b/tests/unit/test_handler.py
@@ -187,10 +187,13 @@ def test_job_list_collector_fails_fast_when_queue_url_missing(
 # ─────────────────────────────────────────────────────────
 
 
+@patch("app.embed_text", return_value=[0.1] * 768)
 @patch("app.S3Storage")
 @patch("app.get_crawler")
-def test_job_detail_crawler_saves_fetched_detail(mock_get_crawler, mock_storage_cls):
-    """상세 크롤링 성공 시 storage.save 가 호출되어야 한다."""
+def test_job_detail_crawler_saves_fetched_detail(
+    mock_get_crawler, mock_storage_cls, mock_embed,
+):
+    """상세 크롤링 성공 시 storage.save 가 임베딩과 함께 호출되어야 한다."""
     mock_storage = MagicMock()
     mock_storage_cls.return_value = mock_storage
 
@@ -210,6 +213,7 @@ def test_job_detail_crawler_saves_fetched_detail(mock_get_crawler, mock_storage_
     mock_storage.save.assert_called_once()
     saved = mock_storage.save.call_args.args[0]
     assert isinstance(saved, JobDetail)
+    assert mock_storage.save.call_args.kwargs["embedding"] == [0.1] * 768
 
 
 @patch("app.S3Storage")


### PR DESCRIPTION
## #️⃣ 연관된 이슈

closes #17

## #️⃣ 작업 내용

### 문제 상황

EC2 t3.micro(1GB RAM)에서 Consumer가 임베딩 모델(KR-SBERT ONNX, ~110MB)을 로딩하면서 반복적으로 OOM/crash가 발생했다. 배포 시 Docker 이미지 pull과 모델 로딩이 겹치면 인스턴스가 뻗어 SSH조차 불가능해지는 상태였으며, swap 추가로도 근본 해결이 되지 않았다.

### 해결 전략

임베딩 계산을 EC2에서 완전히 제거하고 Lambda로 이전한다.

#### 변경 전

```
Lambda (크롤링) → S3 (텍스트 JSON) → Consumer (모델 로딩 + 임베딩 계산 + 저장) → ChromaDB
```

#### 변경 후

```
Lambda (크롤링 + 임베딩 계산) → S3 (텍스트 + 벡터 JSON) → Consumer (저장만) → ChromaDB
```

### 상세 변경 사항

#### 1. 임베딩 로직 독립 모듈 추출 (`src/embedding.py`)

`storage/chromadb.py`에 있던 `OnnxEmbeddingFunction` 클래스의 핵심 로직을 독립 모듈로 추출했다.

- `embed_text(text)` — 문단 청킹 + 토큰 수 가중 평균 + L2 정규화
- `build_document(raw_text, tech_stack)` — 임베딩 대상 document 문자열 조합
- ONNX 세션은 모듈 레벨에서 1회 로딩하여 Lambda 웜 스타트 시 재사용

#### 2. Lambda 컨테이너 이미지 전환 (`src/Dockerfile`)

`job_detail_crawler` Lambda를 ZIP 배포 → 컨테이너 이미지로 전환하여 ONNX 양자화 모델(~110MB)을 포함한다.

```
Stage 1 (builder): PyTorch + optimum → KR-SBERT ONNX 변환 → 양자화(QUInt8)
Stage 2 (runtime): public.ecr.aws/lambda/python:3.11 + onnxruntime + 양자화 모델
```

| 설정 | 변경 전 | 변경 후 |
|------|---------|---------|
| PackageType | ZIP | **Image** |
| MemorySize | 256MB | **512MB** |
| Timeout | 60s | **120s** |

#### 3. S3 JSON 스키마 확장

`storage/s3.py`의 `save()` 메서드에 `embedding` 파라미터를 추가했다. Lambda가 계산한 768차원 벡터가 JSON에 포함되어 S3에 저장된다.

```json
{
  "source": "jobkorea",
  "raw_text": "...",
  "tech_stack": ["Python", "AWS"],
  "embedding": [0.12, -0.34, ...],  // NEW: 768차원 벡터
  ...
}
```

#### 4. Consumer 경량화

- `OnnxEmbeddingFunction` 클래스 삭제 — embedding_function 없이 컬렉션 생성
- S3 JSON에서 `embedding` 필드를 읽어 `collection.upsert(embeddings=[...])` 직접 전달
- Dockerfile에서 ONNX 멀티스테이지 빌드 제거 → 단순 `python:3.11-slim`
- `requirements.txt`에서 `onnxruntime`, `transformers`, `numpy` 제거

#### 5. CI/CD

- `template.yaml`: `JobDetailCrawler`에 `PackageType: Image` + `Metadata` (Dockerfile 경로) 추가
- `deploy.yml`: `sam deploy`에 `--resolve-image-repos` 추가 (컨테이너 이미지 ECR 자동 생성)

### 메모리 예상

| 구성 | 변경 전 | 변경 후 |
|------|---------|---------|
| Lambda (job_detail_crawler) | 256MB | 512MB (ONNX 모델 포함, ~260MB 사용) |
| EC2 Consumer + ChromaDB | ~370MB (OOM) | **~53MB** |

### 변경 파일

| 파일 | 변경 |
|------|------|
| `src/embedding.py` | **신규** — 임베딩 로직 독립 모듈 |
| `src/Dockerfile` | **신규** — Lambda 컨테이너 이미지 |
| `src/app.py` | 임베딩 계산 추가 (`embed_text`, `build_document` 호출) |
| `src/storage/s3.py` | `save()`에 `embedding` 파라미터 추가 |
| `src/storage/chromadb.py` | `OnnxEmbeddingFunction` 제거, 사전 계산 벡터 직접 저장 |
| `src/requirements.txt` | `onnxruntime`, `transformers`, `numpy` 추가 |
| `consumer/consumer.py` | `embedding` 필드 읽어서 전달 |
| `consumer/Dockerfile` | ONNX 빌드 스테이지 제거, 경량화 |
| `consumer/requirements.txt` | ONNX 의존성 제거 |
| `template.yaml` | `PackageType: Image`, 512MB, 120s |
| `.github/workflows/deploy.yml` | `--resolve-image-repos` 추가 |
| `tests/unit/test_handler.py` | `embed_text` mock 추가 |

## #️⃣ 테스트 결과

기존 단위 테스트 37개 모두 통과.

```
tests/unit/test_handler.py         — 12 passed
tests/unit/test_consumer.py        — 5 passed
tests/unit/test_parser_jobkorea.py — 16 passed
tests/unit/test_s3_storage.py      — 4 passed
======================== 37 passed in 0.37s =========================
```

- `embed_text`를 mock하여 ONNX 모델 없이도 핸들러 테스트 통과
- 임베딩이 `storage.save()`에 `embedding` kwarg로 정상 전달되는지 검증

## #️⃣ 변경 사항 체크리스트

- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [x] 문서를 작성하거나 수정했나요? (필요한 경우)
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## #️⃣ 리뷰 요구사항 (선택)

- `src/Dockerfile`: Lambda 컨테이너 이미지 멀티스테이지 빌드가 `sam build`에서 정상 동작하는지 확인 필요
- `template.yaml`: `PackageType: Image` 전환 시 기존 ZIP 기반 Lambda 스택과 충돌 없는지 확인 필요 (CloudFormation 스택 업데이트 시 리소스 교체 발생 가능)
- Consumer가 `embedding` 필드 없는 기존 S3 JSON도 처리할 수 있도록 `data.get("embedding")` 방어 처리 확인

## 📎 참고 자료 (선택)

- #14 — 임베딩 모델 경량화 (KR-SBERT ONNX 양자화 + 문단 청킹)
- #2 — 크롤링 파이프라인 전체 이슈