### PR TITLE
fix: Lambda 컨테이너 이미지에서 numpy 빌드 실패 수정 (#17)

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -2,4 +2,4 @@ requests
 beautifulsoup4
 onnxruntime
 transformers
-numpy
+numpy<2


### PR DESCRIPTION
## #️⃣  연관된 이슈

  #17                                                                                       
   
  ## #️⃣  작업 내용                                                                           
                                                            
  Lambda 컨테이너 이미지 빌드 시 `numpy` 설치가 실패하는 문제를 수정했다.                   
  
  Lambda 베이스 이미지(`public.ecr.aws/lambda/python:3.11`)에는 C 컴파일러(`gcc`)가 포함되어있지 않다. `numpy>=2.4`는 사전 빌드된 wheel이 이 환경과 호환되지 않아 소스 빌드를 시도하는데, 컴파일러가 없으므로 실패한다.                                                 
                                                            
  `ERROR: Unknown compiler(s): [['cc'], ['gcc'], ['clang']]`                
  
  `numpy<2`로 버전을 제한하여 사전 빌드된 wheel(1.x)을 사용하도록 했다.

## #️⃣  변경 사항 체크리스트                                                                
                                                            
  - [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?                   
  - [x] 문서를 작성하거나 수정했나요? (필요한 경우)
  - [x] 코드 컨벤션에 따라 코드를 작성했나요?                                               
  - [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?