### PR TITLE
fix: PackageType Image와 Globals Runtime 충돌 수정 (#17)

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -11,7 +11,6 @@ Parameters:
 
 Globals:
   Function:
-    Runtime: python3.11
     Architectures:
       - x86_64
     Timeout: 300
@@ -57,6 +56,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       FunctionName: passroute-job-list-collector
+      Runtime: python3.11
       CodeUri: src/
       Handler: app.job_list_collector
       Timeout: 900


### PR DESCRIPTION
## #️⃣  연관된 이슈
           
  #17
                                                                                            
## #️⃣  작업 내용
                                                                                            
  - SAM 템플릿의 Globals.Function.Runtime: python3.11이 PackageType: Image인 JobDetailCrawler에도 적용되어 배포 시 충돌 에러가 발생하는 문제를 수정했습니다.                                                                                       
  - Globals에서 Runtime을 제거하고, zip 배포 방식인 JobListCollector에만 개별 지정          
 

## #️⃣ 변경 사항 체크리스트

- [ ] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
- [ ] 코드 컨벤션에 따라 코드를 작성했나요?
- [ ] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?
