### PR TITLE
feat: DLQ 알람 Discord 웹훅 알림 연동 (#21)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,4 +48,5 @@ jobs:
             --resolve-s3 \
             --resolve-image-repos \
             --parameter-overrides \
-              S3BucketName=${{ secrets.S3_BUCKET_NAME }}
+              S3BucketName=${{ secrets.S3_BUCKET_NAME }} \
+              DiscordWebhookUrl=${{ secrets.DISCORD_WEBHOOK_URL }}

--- a/src/notify.py
+++ b/src/notify.py
@@ -1,0 +1,61 @@
+"""DLQ 알람 → Discord 웹훅 알림 Lambda 핸들러."""
+
+import json
+import logging
+import os
+import urllib.request
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+
+def discord_notifier(event, _context):
+    """SNS 메시지를 받아 Discord 웹훅으로 전송한다."""
+    webhook_url = os.environ.get("DISCORD_WEBHOOK_URL")
+    if not webhook_url:
+        logger.error("DISCORD_WEBHOOK_URL 환경변수 누락")
+        return
+
+    for record in event.get("Records", []):
+        sns_message = record.get("Sns", {})
+        subject = sns_message.get("Subject", "알람")
+        raw_message = sns_message.get("Message", "")
+
+        try:
+            alarm = json.loads(raw_message)
+            alarm_name = alarm.get("AlarmName", "")
+            description = alarm.get("AlarmDescription", "")
+            reason = alarm.get("NewStateReason", "")
+            region = alarm.get("Region", "")
+            timestamp = alarm.get("StateChangeTime", "")
+
+            embed = {
+                "title": f"\u26a0\ufe0f {alarm_name}",
+                "description": description,
+                "color": 0xFF4444,
+                "fields": [
+                    {"name": "\uc6d0\uc778", "value": reason, "inline": False},
+                    {"name": "\ub9ac\uc804", "value": region, "inline": True},
+                    {"name": "\ubc1c\uc0dd \uc2dc\uac01", "value": timestamp, "inline": True},
+                ],
+            }
+            payload = {"embeds": [embed]}
+        except (json.JSONDecodeError, KeyError):
+            payload = {
+                "content": f"**{subject}**\n```\n{raw_message[:1500]}\n```",
+            }
+
+        data = json.dumps(payload).encode("utf-8")
+        req = urllib.request.Request(
+            webhook_url,
+            data=data,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+
+        try:
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                logger.info("Discord 알림 전송 완료: status=%d", resp.status)
+        except Exception:
+            logger.exception("Discord 웹훅 전송 실패")
+            raise

--- a/template.yaml
+++ b/template.yaml
@@ -8,6 +8,11 @@ Parameters:
     Type: String
     Description: 크롤링 데이터 중간 저장 S3 버킷명
     Default: passroute-crawler-data-0607
+  DiscordWebhookUrl:
+    Type: String
+    Description: DLQ 알람 Discord 웹훅 URL
+    NoEcho: true
+    Default: ''
 
 Globals:
   Function:
@@ -75,13 +80,29 @@ Resources:
             Schedule: cron(0 18 * * ? *)
             Enabled: false
 
-  # ── DLQ 알람 ──
-  # SNS 토픽만 생성해두고 구독(이메일/슬랙)은 콘솔에서 수동 추가.
+  # ── DLQ 알람 → Discord 알림 ──
   DLQAlarmTopic:
     Type: AWS::SNS::Topic
     Properties:
       TopicName: passroute-dlq-alarm
       DisplayName: passroute DLQ Alarm
+
+  DLQDiscordNotifier:
+    Type: AWS::Serverless::Function
+    Properties:
+      Runtime: python3.11
+      CodeUri: src/
+      Handler: notify.discord_notifier
+      Timeout: 30
+      MemorySize: 128
+      Environment:
+        Variables:
+          DISCORD_WEBHOOK_URL: !Ref DiscordWebhookUrl
+      Events:
+        SNSTrigger:
+          Type: SNS
+          Properties:
+            Topic: !Ref DLQAlarmTopic
 
   JobDetailDLQAlarm:
     Type: AWS::CloudWatch::Alarm
@@ -137,5 +158,5 @@ Outputs:
     Description: 크롤링 데이터 S3 버킷명
     Value: !Ref CrawlerDataBucket
   DLQAlarmTopicArn:
-    Description: DLQ 알람 SNS 토픽 ARN (구독은 콘솔에서 수동 추가)
+    Description: DLQ 알람 SNS 토픽 ARN
     Value: !Ref DLQAlarmTopic


### PR DESCRIPTION
## #️⃣ 연관된 이슈

closes #21

## #️⃣ 작업 내용

DLQ에 실패 메시지가 쌓이면 Discord 채널로 자동 알림을 전송하는 기능 구현.

- `src/notify.py` — SNS 메시지를 Discord embed 형식으로 변환하여 웹훅 전송하는 Lambda 핸들러
- `template.yaml` — `DiscordWebhookUrl` 파라미터 + `DLQDiscordNotifier` Lambda + SNS 구독 추가
- `.github/workflows/deploy.yml` — `DiscordWebhookUrl` 파라미터 전달 추가

### 알림 흐름

```
CloudWatch Alarm (DLQ 메시지 > 0, 5분 주기)
    → SNS (passroute-dlq-alarm)
    → Lambda (DLQDiscordNotifier)
    → Discord Webhook
```

## #️⃣ 테스트 결과

- 배포 전 GitHub Secrets에 `DISCORD_WEBHOOK_URL` 등록 필요
- 배포 후 DLQ 알람 트리거 시 Discord 알림 수신 확인 예정

## #️⃣ 변경 사항 체크리스트

- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [x] 문서를 작성하거나 수정했나요? (필요한 경우)
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## #️⃣ 리뷰 요구사항 (선택)

- `notify.py`에서 외부 의존성 없이 `urllib.request`만 사용하여 Discord 웹훅 호출 — 별도 requirements 추가 불필요
- `DiscordWebhookUrl` 파라미터는 `NoEcho: true`로 CloudFormation 콘솔/로그에서 마스킹됨