### PR TITLE
fix: 잡코리아 목록 조회 GET→POST 전환으로 직무 필터 적용 (#23)

### DIFF
--- a/src/crawler/jobkorea.py
+++ b/src/crawler/jobkorea.py
@@ -24,6 +24,7 @@ KST = timezone(timedelta(hours=9))
 
 BASE_URL = "https://www.jobkorea.co.kr"
 LIST_URL = f"{BASE_URL}/recruit/joblist"
+GI_LIST_URL = f"{LIST_URL}/_GI_List/"
 DETAIL_URL = f"{BASE_URL}/Recruit/GI_Read"
 IFRAME_URL = f"{BASE_URL}/Recruit/GI_Read_Comt_Ifrm"
 
@@ -105,6 +106,7 @@ class JobKoreaCrawler(JobCrawler):
         self.session = requests.Session()
         headers = dict(BASE_HEADERS)
         headers["User-Agent"] = random.choice(USER_AGENTS)
+        headers["X-Requested-With"] = "XMLHttpRequest"
         self.session.headers.update(headers)
 
     @classmethod
@@ -112,14 +114,20 @@ class JobKoreaCrawler(JobCrawler):
         return f"{DETAIL_URL}/{external_id}"
 
     def fetch_listings_page(self, page: int) -> list[JobListingRef]:
-        params = {
-            "menucode": "duty",
-            "dutyCtgr": DUTY_GROUP_CODE,
-            "duty": ",".join(self.category_codes),
-            "orderTab": "3",  # 최신업데이트순
-            "Page": page,
+        data = {
+            "isDefault": "false",
+            "condition[duty]": ",".join(self.category_codes),
+            "condition[menucode]": "duty",
+            "page": page,
+            "direct": "0",
+            "order": "3",  # 최신업데이트순
+            "pagesize": "40",
+            "tabindex": "0",
+            "onePick": "0",
+            "confirm": "0",
+            "profile": "0",
         }
-        resp = self.session.get(LIST_URL, params=params, timeout=15)
+        resp = self.session.post(GI_LIST_URL, data=data, timeout=15)
         resp.raise_for_status()
         return [
             JobListingRef(


### PR DESCRIPTION
## #️⃣ 연관된 이슈

Closes #23

## #️⃣ 작업 내용

잡코리아 목록 조회 시 GET 방식에서 POST 방식으로 전환하여, 직무 카테고리 필터가 실제로 적용되도록 수정한다.

### 문제 상황

기존 코드는 `GET /recruit/joblist?duty=1000229,...` 방식으로 목록을 요청했다. 그러나 잡코리아 서버는 **GET URL의 `duty` 파라미터를 검색 필터링에 사용하지 않는다.** URL 파라미터는 브라우저 UI의 필터 선택 상태를 표시하는 용도일 뿐이며, 실제 필터링은 "선택된 조건 검색하기" 버튼 클릭 시 POST로 전송되는 form data를 통해 동작한다.

결과적으로 전체 196,966건의 공고가 무필터로 반환되어, 이디야(커피 프랜차이즈), 극동건설(건설), DS단석(화학 사무/연구직) 등 **비개발 직무 공고가 크롤링 결과에 포함**되고 있었다.

| 요청 방식 | 반환 건수 |
|----------|---------:|
| GET (기존, 필터 미적용) | 196,966건 |
| POST 백엔드 1개 카테고리 | 1,651건 |
| POST 20개 카테고리 통합 | 7,943건 |

### 변경 내용

**1. 엔드포인트 변경**: `GET /recruit/joblist` → `POST /recruit/joblist/_GI_List/`

잡코리아의 실제 검색 백엔드는 `_GI_List/` 경로이다. 브라우저 네트워크 탭에서 "선택된 조건 검색하기" 버튼 클릭 시 이 엔드포인트로 POST 요청이 전송됨을 확인했다. 기존 `/recruit/joblist` 경로는 SSR 페이지를 반환하는 용도로, 검색 조건을 반영하지 않는다.

**2. 파라미터 형식 변경**: URL query string → POST form data

```
# 기존 (GET query string — 필터 미적용)
menucode=duty&dutyCtgr=10031&duty=1000229,...&orderTab=3&Page=1

# 변경 (POST form data — 필터 적용)
isDefault=false
condition[duty]=1000229,...
condition[menucode]=duty
page=1
order=3
pagesize=40
...
```

`condition[duty]`로 직무 코드를 전달해야 서버가 실제 필터링을 수행한다. `order=3`은 기존 `orderTab=3`과 동일한 최신업데이트순 정렬이므로, **stale 감지 로직의 전제(최신업데이트순 정렬)가 그대로 유지**된다.

**3. AJAX 헤더 추가**: `X-Requested-With: XMLHttpRequest`

`_GI_List/` 엔드포인트는 AJAX 전용 백엔드로, 이 헤더 없이 요청하면 빈 응답이나 리다이렉트가 반환될 수 있다. 브라우저가 실제로 전송하는 헤더를 그대로 포함시켜 안정적인 응답을 확보한다.

### 파서 호환성

`_GI_List/` 응답은 기존 GET 응답과 동일한 `<table><tbody><tr>` HTML 구조를 반환한다. 따라서 **기존 `parse_job_list` 파서는 수정 없이 그대로 호환**된다. 이 점은 실제 POST 응답 HTML을 비교하여 확인했다.

### 설계 판단: form data 필드 선택 근거

POST form data에 `direct`, `tabindex`, `onePick`, `confirm`, `profile` 등 부가 필드를 포함했다. 이 필드들은 브라우저 네트워크 탭에서 캡처한 실제 요청에 포함되어 있던 값이다. 잡코리아 서버가 이 필드의 유무로 요청을 검증할 가능성을 배제할 수 없으므로, 브라우저 동작을 충실히 재현하기 위해 모두 포함했다. 값은 모두 기본값(0 또는 false)이므로 검색 결과에 영향을 주지 않는다.

## #️⃣ 테스트 결과

- `local_smoke.py` 실행으로 POST 전환 후 개발 직무 공고만 반환되는 것 확인
- 기존 단위 테스트 (`pytest tests/unit/`) 통과 확인

## #️⃣ 변경 사항 체크리스트

- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## #️⃣ 리뷰 요구사항 (선택)

- `_GI_List/` 엔드포인트의 form data 필드 구성이 적절한지 확인 부탁드립니다
- `pagesize=40`이 잡코리아 기본값인데, 기존 GET 방식의 페이지당 건수와 동일한지 확인 필요