### PR TITLE
feat: 채용 공고 경력 수준(career_level) 메타데이터 추가 (#25)

### DIFF
--- a/consumer/consumer.py
+++ b/consumer/consumer.py
@@ -55,6 +55,7 @@ def process_parsed_files(s3, bucket: str, storage: ChromaDBStorage) -> int:
                     tech_stack=tuple(data.get("tech_stack", [])),
                     deadline=data.get("deadline", ""),
                     crawled_at=data["crawled_at"],
+                    career_level=data.get("career_level", ""),
                 )
 
                 embedding = data.get("embedding")

--- a/scripts/local_smoke.py
+++ b/scripts/local_smoke.py
@@ -36,7 +36,7 @@ def main() -> int:
     refs = crawler.fetch_listings_page(page)
     print(f"총 {len(refs)}건")
     for ref in refs[:10]:
-        print(f"  - [{ref.external_id}] {ref.company_name} | {ref.title}")
+        print(f"  - [{ref.external_id}] {ref.company_name} | {ref.title} [{ref.career_level}]")
         print(f"    {ref.url}")
 
     if not refs:

--- a/src/crawler/base.py
+++ b/src/crawler/base.py
@@ -17,6 +17,7 @@ class JobListingRef:
     url: str
     title: str
     company_name: str
+    career_level: str = ""
 
 
 @dataclass(frozen=True)
@@ -31,6 +32,7 @@ class JobDetail:
     tech_stack: tuple[str, ...]
     deadline: str
     crawled_at: str
+    career_level: str = ""
 
 
 DEFAULT_DELAY_MIN = 1.0

--- a/src/crawler/jobkorea.py
+++ b/src/crawler/jobkorea.py
@@ -128,6 +128,7 @@ class JobKoreaCrawler(JobCrawler):
                 url=self.detail_url(item.job_id),
                 title=item.title,
                 company_name=item.company_name,
+                career_level=item.career_level,
             )
             for item in parse_job_list(resp.text)
         ]
@@ -159,6 +160,7 @@ class JobKoreaCrawler(JobCrawler):
             tech_stack=metadata.tech_stack,
             deadline=metadata.deadline,
             crawled_at=datetime.now(KST).isoformat(),
+            career_level=ref.career_level,
         )
 
 

--- a/src/parser/jobkorea.py
+++ b/src/parser/jobkorea.py
@@ -25,6 +25,7 @@ class JobkoreaListItem:
     job_id: str
     title: str
     company_name: str
+    career_level: str = ""
 
 
 def parse_job_list(html: str) -> list[JobkoreaListItem]:
@@ -40,10 +41,17 @@ def parse_job_list(html: str) -> list[JobkoreaListItem]:
         if not match:
             continue
         company_tag = row.select_one('a[href*="/Recruit/Co_Read/"]')
+        career_level = ""
+        etc_tag = row.select_one("p.etc")
+        if etc_tag:
+            first_cell = etc_tag.select_one("span.cell")
+            if first_cell:
+                career_level = first_cell.get_text(strip=True)
         jobs.append(JobkoreaListItem(
             job_id=match.group(1),
             title=link.get_text(strip=True),
             company_name=company_tag.get_text(strip=True) if company_tag else "",
+            career_level=career_level,
         ))
 
     return jobs

--- a/src/storage/chromadb.py
+++ b/src/storage/chromadb.py
@@ -44,6 +44,7 @@ class ChromaDBStorage:
                 "deadline": detail.deadline,
                 "crawled_at": detail.crawled_at,
                 "tech_stack": _tech_stack_to_str(detail.tech_stack),
+                "career_level": detail.career_level,
             }],
         }
         if embedding is not None:

--- a/src/storage/s3.py
+++ b/src/storage/s3.py
@@ -44,6 +44,7 @@ class S3Storage:
             "tech_stack": list(detail.tech_stack),
             "deadline": detail.deadline,
             "crawled_at": detail.crawled_at,
+            "career_level": detail.career_level,
         }
         if embedding is not None:
             data["embedding"] = embedding


### PR DESCRIPTION
## #️⃣ 연관된 이슈

Closes #25

## #️⃣ 작업 내용

잡코리아 목록 페이지에서 경력 수준(신입, 경력, 인턴 등)을 추출하여 `career_level` 필드로 전체 파이프라인(파서 → 크롤러 → S3 → Consumer → ChromaDB)에 전달·저장한다.

### 데이터 소스 선택: 목록 페이지 vs 상세 페이지

경력 수준 정보는 **목록 페이지**와 **상세 페이지** 두 곳에서 존재 가능성을 검토했다.

| 소스 | 위치 | 적합성 |
|------|------|--------|
| 목록 페이지 `<p class="etc">` | 첫 번째 `<span class="cell">` | 모든 공고에 존재, 추가 HTTP 요청 불필요 |
| 상세 페이지 `__next_f` JSON | 별도 필드 없음 | 경력 수준 전용 필드가 존재하지 않음 |

**목록 페이지를 선택한 이유**: 상세 페이지의 `__next_f` JSON을 전수 조사한 결과 경력 수준에 해당하는 필드가 없었다. 반면 목록 페이지의 `<p class="etc">` 첫 번째 `<span class="cell">`에는 잡코리아가 구조화한 형태(`신입`, `경력3년↑`, `신입·경력` 등)로 이미 제공하고 있다. 기존 `parse_job_list`가 각 `<tr>`을 순회하는 시점에 함께 추출하면 **추가 HTTP 요청 없이 확보 가능**하다.

### HTML 파싱 구조

```html
<p class="etc">
    <span class="cell">신입</span>        ← career_level (첫 번째 cell)
    <span class="cell">대졸↑</span>       ← 학력
    <span class="cell">서울 서초구</span>  ← 지역
    <span class="cell">인턴</span>        ← 고용형태
</p>
```

`<p class="etc">` 내 `<span class="cell">` 순서는 잡코리아 전체에서 일관되며 (경력 → 학력 → 지역 → 고용형태), 첫 번째 cell이 항상 경력 수준이다. `select_one("span.cell")`로 첫 번째만 가져오므로 순서 의존성 문제가 없다.

### 데이터 흐름 설계

```
parse_job_list()                    → JobkoreaListItem.career_level
  ↓
fetch_listings_page()               → JobListingRef.career_level
  ↓
fetch_detail()                      → JobDetail.career_level (ref에서 복사)
  ↓
S3Storage.save()                    → parsed/{source}/{id}.json
  ↓
Consumer                            → S3 JSON에서 career_level 읽기
  ↓
ChromaDBStorage.save()              → metadata["career_level"]
```

**`ref → detail` 복사 방식을 택한 이유**: 상세 페이지에서 career_level을 독립적으로 추출할 수 없으므로, 목록 단계에서 추출한 값을 `ref.career_level`로 보관했다가 `fetch_detail()` 시 `JobDetail`에 그대로 전달한다. 이 방식은 추가 HTTP 요청을 발생시키지 않으며, 목록과 상세 간 데이터 일관성을 보장한다.

### 기본값 `""` 설계 근거

`JobListingRef`와 `JobDetail`은 `base.py`의 **크롤러 공통 인터페이스**이므로, 잡코리아 외 다른 사이트 크롤러에서 career_level을 제공하지 않아도 동작해야 한다. `career_level: str = ""`로 선언하면:

- 기존 크롤러 코드가 career_level 인자를 전달하지 않아도 `TypeError` 없이 동작
- S3/ChromaDB에 빈 문자열로 저장되어 필드 존재 여부 불일치 방지
- Consumer에서 `data.get("career_level", "")`로 읽어 **기존 S3 파일과의 하위 호환성 유지** (career_level 필드가 없는 기존 JSON도 정상 처리)

### 변경 파일별 상세

| 파일 | 변경 내용 |
|------|----------|
| `src/crawler/base.py` | `JobListingRef`, `JobDetail`에 `career_level: str = ""` 필드 추가 |
| `src/parser/jobkorea.py` | `JobkoreaListItem`에 필드 추가 + `parse_job_list`에서 `<p class="etc">` 파싱 |
| `src/crawler/jobkorea.py` | `fetch_listings_page`에서 `career_level=item.career_level` 전달, `fetch_detail`에서 `career_level=ref.career_level` 복사 |
| `src/storage/s3.py` | S3 저장 dict에 `career_level` 추가 |
| `src/storage/chromadb.py` | ChromaDB metadatas에 `career_level` 추가 |
| `consumer/consumer.py` | S3 JSON → JobDetail 변환 시 `data.get("career_level", "")` 읽기 |
| `scripts/local_smoke.py` | 목록 출력에 `[career_level]` 표시 추가 |

### career_level 정규화를 하지 않는 이유

잡코리아가 제공하는 원본 값(`신입`, `경력3년↑`, `신입·경력2년↑` 등)을 그대로 저장한다. 정규화(예: `경력3년↑` → `경력`)는 현재 하지 않는 이유:

1. AI 서버에서 면접 질문 난이도 조절 시 **경력 연차 정보(`3년↑`)가 유의미**할 수 있음
2. 정규화 매핑을 정의하려면 잡코리아의 모든 career_level 변형을 파악해야 하는데, 현재 충분한 샘플이 없음
3. 향후 정규화가 필요하면 `parser/common.py`에 매핑을 추가하는 것으로 확장 가능

## #️⃣ 테스트 결과

- 기존 단위 테스트 (`pytest tests/unit/`) 통과 확인
- `local_smoke.py`로 실제 잡코리아 목록에서 career_level 추출 확인

## #️⃣ 변경 사항 체크리스트

- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## #️⃣ 리뷰 요구사항 (선택)

- `<p class="etc">` 첫 번째 `<span class="cell">`이 항상 경력 수준인지, 잡코리아 페이지 구조 변경 가능성에 대한 의견 부탁드립니다
- SQS 메시지에는 career_level을 포함하지 않았습니다 (목록 단계 식별 정보만 전송하는 기존 설계 유지). 상세 Lambda에서 ref를 통해 전달받으므로 문제없으나, 의견 있으시면 코멘트 부탁드립니다