### PR TITLE
feat: ChromaDB deadline 메타데이터 Unix timestamp(int) 전환

### DIFF
--- a/consumer/consumer.py
+++ b/consumer/consumer.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import time
+from datetime import datetime
 
 import boto3
 from botocore.exceptions import ClientError
@@ -82,7 +83,11 @@ def process_delete_requests(s3, bucket: str, storage: ChromaDBStorage) -> int:
             try:
                 resp = s3.get_object(Bucket=bucket, Key=key)
                 data = json.loads(resp["Body"].read().decode("utf-8"))
-                count = storage.delete_expired(data["now_iso"])
+                now_ts = data.get("now_ts")
+                if now_ts is None:
+                    now_iso = data.get("now_iso", "")
+                    now_ts = int(datetime.fromisoformat(now_iso).timestamp())
+                count = storage.delete_expired(now_ts)
                 deleted += count
                 s3.delete_object(Bucket=bucket, Key=key)
                 logger.info("삭제 요청 처리 완료: %s (%d건 삭제)", key, count)
@@ -117,6 +122,7 @@ def main():
     s3 = _build_s3()
 
     logger.info("consumer 시작: bucket=%s, poll_interval=%ds", bucket, POLL_INTERVAL)
+    storage.migrate_deadline_to_ts()
 
     while True:
         try:

--- a/src/storage/chromadb.py
+++ b/src/storage/chromadb.py
@@ -1,6 +1,7 @@
 """ChromaDB HTTP 클라이언트. 사전 계산된 임베딩으로 JD 를 저장하고 URL 기준 중복 제거."""
 import logging
 from collections.abc import Iterable
+from datetime import datetime, timezone
 
 import chromadb
 
@@ -41,7 +42,7 @@ class ChromaDBStorage:
                 "company_name": detail.company_name,
                 "title": detail.title,
                 "url": detail.url,
-                "deadline": detail.deadline,
+                "deadline": _deadline_to_ts(detail.deadline),
                 "crawled_at": detail.crawled_at,
                 "tech_stack": _tech_stack_to_str(detail.tech_stack),
                 "career_level": detail.career_level,
@@ -53,10 +54,10 @@ class ChromaDBStorage:
         self.collection.upsert(**upsert_kwargs)
         logger.info("저장 완료: %s - %s", detail.company_name, detail.title)
 
-    def delete_expired(self, now_iso: str) -> int:
-        """마감일이 지난 공고 삭제. 상시채용(deadline="")은 제외."""
+    def delete_expired(self, now_ts: int) -> int:
+        """마감일이 지난 공고 삭제. 상시채용(deadline=0)은 제외."""
         results = self.collection.get(
-            where={"$and": [{"deadline": {"$lt": now_iso}}, {"deadline": {"$ne": ""}}]}
+            where={"$and": [{"deadline": {"$lt": now_ts}}, {"deadline": {"$gt": 0}}]}
         )
         expired_ids = results.get("ids") or []
         if not expired_ids:
@@ -64,6 +65,33 @@ class ChromaDBStorage:
         self.collection.delete(ids=expired_ids)
         logger.info("마감 공고 %d건 삭제", len(expired_ids))
         return len(expired_ids)
+
+    def migrate_deadline_to_ts(self) -> int:
+        """기존 문자열 deadline 을 Unix timestamp 로 마이그레이션한다."""
+        migrated = 0
+        offset = 0
+
+        while True:
+            results = self.collection.get(include=["metadatas"], limit=_URL_FETCH_CHUNK, offset=offset)
+            ids = results.get("ids") or []
+            metadatas = results.get("metadatas") or []
+            if not ids:
+                break
+
+            for doc_id, meta in zip(ids, metadatas):
+                deadline = meta.get("deadline")
+                if isinstance(deadline, str):
+                    meta["deadline"] = _deadline_to_ts(deadline)
+                    self.collection.update(ids=[doc_id], metadatas=[meta])
+                    migrated += 1
+
+            if len(ids) < _URL_FETCH_CHUNK:
+                break
+            offset += _URL_FETCH_CHUNK
+
+        if migrated > 0:
+            logger.info("deadline 마이그레이션 완료: %d건", migrated)
+        return migrated
 
     def get_all_urls(self) -> set[str]:
         """저장된 모든 공고 URL 을 청크 단위로 조회."""
@@ -87,3 +115,16 @@ class ChromaDBStorage:
 
 def _tech_stack_to_str(tech_stack: Iterable[str]) -> str:
     return ", ".join(tech_stack)
+
+
+def _deadline_to_ts(deadline: str) -> int:
+    """ISO8601 마감일 문자열을 Unix timestamp(초)로 변환. 빈 문자열(상시채용)은 0."""
+    if not deadline:
+        return 0
+    try:
+        dt = datetime.fromisoformat(deadline)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return int(dt.timestamp())
+    except ValueError:
+        return 0

--- a/src/storage/s3.py
+++ b/src/storage/s3.py
@@ -55,9 +55,11 @@ class S3Storage:
 
     def delete_expired(self, now_iso: str) -> int:
         """마감 삭제 요청을 S3 에 기록. 실제 삭제는 EC2 consumer 가 처리."""
+        now_dt = datetime.fromisoformat(now_iso)
+        now_ts = int(now_dt.timestamp())
         timestamp = datetime.now(KST).strftime("%Y%m%dT%H%M%S")
         key = f"delete-requests/{timestamp}.json"
-        body = json.dumps({"now_iso": now_iso, "requested_at": timestamp})
+        body = json.dumps({"now_ts": now_ts, "requested_at": timestamp})
 
         self.s3.put_object(Bucket=self.bucket, Key=key, Body=body.encode("utf-8"))
         logger.info("삭제 요청 저장: %s", key)

--- a/tests/unit/test_consumer.py
+++ b/tests/unit/test_consumer.py
@@ -98,7 +98,7 @@ def test_process_delete_requests_calls_delete_expired():
     """삭제 요청 파일을 읽어 storage.delete_expired 를 호출한다."""
     mock_s3 = _mock_s3_list(["delete-requests/20260412T180000.json"])
     _mock_s3_get_object(mock_s3, {
-        "now_iso": "2026-04-12T18:00:00+09:00",
+        "now_ts": 1776164400,
         "requested_at": "20260412T180000",
     })
 
@@ -108,7 +108,25 @@ def test_process_delete_requests_calls_delete_expired():
     deleted = process_delete_requests(mock_s3, "test-bucket", mock_storage)
 
     assert deleted == 3
-    mock_storage.delete_expired.assert_called_once_with("2026-04-12T18:00:00+09:00")
+    mock_storage.delete_expired.assert_called_once_with(1776164400)
+
+
+def test_process_delete_requests_legacy_now_iso():
+    """기존 now_iso 형식의 삭제 요청도 timestamp 로 변환하여 처리한다."""
+    mock_s3 = _mock_s3_list(["delete-requests/20260412T180000.json"])
+    _mock_s3_get_object(mock_s3, {
+        "now_iso": "2026-04-12T18:00:00+09:00",
+        "requested_at": "20260412T180000",
+    })
+
+    mock_storage = MagicMock()
+    mock_storage.delete_expired.return_value = 1
+
+    deleted = process_delete_requests(mock_s3, "test-bucket", mock_storage)
+
+    assert deleted == 1
+    call_args = mock_storage.delete_expired.call_args.args[0]
+    assert isinstance(call_args, int)
     mock_s3.delete_object.assert_called_once_with(
         Bucket="test-bucket", Key="delete-requests/20260412T180000.json",
     )

--- a/tests/unit/test_s3_storage.py
+++ b/tests/unit/test_s3_storage.py
@@ -92,4 +92,6 @@ def test_delete_expired_writes_request_and_returns_zero(mock_boto_client):
     assert call_kwargs["Key"].endswith(".json")
 
     body = json.loads(call_kwargs["Body"])
-    assert body["now_iso"] == "2026-04-12T18:00:00+09:00"
+    from datetime import datetime
+    expected_ts = int(datetime.fromisoformat("2026-04-12T18:00:00+09:00").timestamp())
+    assert body["now_ts"] == expected_ts


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#29

## #️⃣ 작업 내용

ChromaDB의 `deadline` 메타데이터를 ISO8601 문자열에서 Unix timestamp(int, 초)로 전환하여 마감 공고 삭제 로직의 정확성을 확보한다.

- `src/storage/chromadb.py`
  - `upsert()`: `_deadline_to_ts()`로 변환하여 저장
  - `delete_expired()`: 파라미터를 `now_ts: int`로 변경, `$lt` / `$gt` 숫자 비교 적용
  - `migrate_deadline_to_ts()`: 기존 문자열 deadline을 Unix timestamp로 일괄 마이그레이션
  - `_deadline_to_ts()`: ISO8601 → Unix timestamp 변환 헬퍼 (빈 문자열/상시채용 → `0`)
- `src/storage/s3.py`
  - `delete_expired()`: 삭제 요청 JSON에 `now_ts` 필드 사용
- `consumer/consumer.py`
  - `process_delete_requests()`: `now_ts` 우선 사용 + 레거시 `now_iso` 하위호환 처리
  - `main()`: Consumer 시작 시 `migrate_deadline_to_ts()` 호출로 기존 데이터 자동 마이그레이션

## #️⃣ 테스트 결과

- 전체 38개 테스트 통과 (`pytest tests/unit/ -v`)
- 기존 테스트를 `now_ts` 기반으로 수정
- `test_process_delete_requests_legacy_now_iso` 테스트 추가: 레거시 `now_iso` 형식 하위호환 검증

## #️⃣ 변경 사항 체크리스트

- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [x] 문서를 작성하거나 수정했나요? (필요한 경우)
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?
