### PR TITLE
feat: 이미지 JD OCR 처리 파이프라인 구현

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,4 +49,6 @@ jobs:
             --resolve-image-repos \
             --parameter-overrides \
               S3BucketName=${{ secrets.S3_BUCKET_NAME }} \
-              DiscordWebhookUrl=${{ secrets.DISCORD_WEBHOOK_URL }}
+              DiscordWebhookUrl=${{ secrets.DISCORD_WEBHOOK_URL }} \
+              OcrServerUrl=${{ secrets.OCR_SERVER_URL }} \
+              OcrApiKey=${{ secrets.OCR_API_KEY }}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -19,5 +19,14 @@ services:
       - chromadb
     restart: unless-stopped
 
+  ocr:
+    build:
+      context: ./ocr
+    ports:
+      - "8500:8500"
+    environment:
+      - OCR_API_KEY=${OCR_API_KEY}
+    restart: unless-stopped
+
 volumes:
   chroma-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,5 +20,13 @@ services:
       - chromadb
     restart: unless-stopped
 
+  ocr:
+    build:
+      context: ./ocr
+    ports:
+      - "8500:8500"
+    environment:
+      - OCR_API_KEY=${OCR_API_KEY:-}
+
 volumes:
   chroma-data:

--- a/ocr/ocr_server.py
+++ b/ocr/ocr_server.py
@@ -3,17 +3,29 @@ passroute OCR 서버
 
 이미지 JD를 PaddleOCR로 텍스트 변환하는 얇은 HTTP 래퍼.
 ChromaDB EC2에 컨테이너로 띄워서 크롤러 Lambda가 호출한다.
+X-API-Key 헤더로 인증한다 (OCR_API_KEY 환경변수).
 """
 import base64
 import io
+import os
 
 import numpy as np
-from fastapi import FastAPI, HTTPException
+from fastapi import Depends, FastAPI, HTTPException, Request
 from paddleocr import PaddleOCR
 from PIL import Image
 from pydantic import BaseModel
 
 app = FastAPI(title="passroute-ocr")
+
+API_KEY = os.environ.get("OCR_API_KEY", "")
+
+
+def _verify_api_key(request: Request) -> None:
+    """API 키 검증. OCR_API_KEY 미설정 시 인증 비활성화."""
+    if not API_KEY:
+        return
+    if request.headers.get("X-API-Key") != API_KEY:
+        raise HTTPException(status_code=403, detail="invalid API key")
 
 # 서버 기동 시 1회 로드 (첫 요청 지연 방지)
 ocr = PaddleOCR(use_angle_cls=True, lang="korean", show_log=False)
@@ -32,7 +44,7 @@ def health():
     return {"ok": True}
 
 
-@app.post("/ocr", response_model=OCRResponse)
+@app.post("/ocr", response_model=OCRResponse, dependencies=[Depends(_verify_api_key)])
 def run_ocr(req: OCRRequest):
     try:
         raw = base64.b64decode(req.image_b64)

--- a/src/app.py
+++ b/src/app.py
@@ -9,9 +9,11 @@ from datetime import datetime, timedelta, timezone
 
 import boto3
 
-from crawler.base import JobDetail, JobListingRef
+from crawler.base import ImageJobDetail, JobDetail, JobListingRef
 from crawler.registry import get_crawler, iter_sources
 from embedding import build_document, embed_text
+from ocr_client import call_ocr
+from parser.jobkorea import _remove_noise_sections
 from storage.s3 import S3Storage
 
 logger = logging.getLogger(__name__)
@@ -99,6 +101,8 @@ def _dispatch_new_listings(
 def job_detail_crawler(event, context):
     """SQS 트리거. 공고 1건 상세 크롤링 → S3 저장."""
     storage = _make_storage()
+    ocr_server_url = os.environ.get("OCR_SERVER_URL", "")
+    ocr_api_key = os.environ.get("OCR_API_KEY", "")
 
     for record in event["Records"]:
         message = json.loads(record["body"])
@@ -114,10 +118,17 @@ def job_detail_crawler(event, context):
         logger.info("상세 크롤링: source=%s id=%s (%s)", ref.source, ref.external_id, ref.company_name)
 
         try:
-            detail: JobDetail | None = crawler.fetch_detail(ref)
-            if detail is None:
-                logger.info("텍스트 JD 없음, 스킵: id=%s", ref.external_id)
+            result = crawler.fetch_detail(ref)
+            if result is None:
+                logger.info("텍스트·이미지 모두 없음, 스킵: id=%s", ref.external_id)
                 continue
+
+            if isinstance(result, ImageJobDetail):
+                detail = _process_image_jd(result, ocr_server_url, ocr_api_key)
+                if detail is None:
+                    continue
+            else:
+                detail = result
 
             document = build_document(detail.raw_text, detail.tech_stack)
             embedding = embed_text(document)
@@ -127,3 +138,36 @@ def job_detail_crawler(event, context):
             raise
 
     return {"statusCode": 200}
+
+
+def _process_image_jd(
+    image_detail: ImageJobDetail, ocr_server_url: str, ocr_api_key: str = "",
+) -> JobDetail | None:
+    """이미지 JD 를 OCR 처리하여 JobDetail 로 변환."""
+    if not ocr_server_url:
+        logger.info("OCR_SERVER_URL 미설정, 이미지 JD 스킵: id=%s", image_detail.external_id)
+        return None
+
+    raw_text = call_ocr(list(image_detail.images_b64), ocr_server_url, ocr_api_key)
+    if not raw_text.strip():
+        logger.info("OCR 결과 비어있음, 스킵: id=%s", image_detail.external_id)
+        return None
+
+    cleaned = _remove_noise_sections(raw_text)
+    if not cleaned:
+        logger.info("OCR 노이즈 제거 후 텍스트 없음, 스킵: id=%s", image_detail.external_id)
+        return None
+
+    logger.info("OCR 완료: id=%s, %d자", image_detail.external_id, len(cleaned))
+    return JobDetail(
+        source=image_detail.source,
+        external_id=image_detail.external_id,
+        url=image_detail.url,
+        company_name=image_detail.company_name,
+        title=image_detail.title,
+        raw_text=cleaned,
+        tech_stack=image_detail.tech_stack,
+        deadline=image_detail.deadline,
+        crawled_at=image_detail.crawled_at,
+        career_level=image_detail.career_level,
+    )

--- a/src/app.py
+++ b/src/app.py
@@ -13,7 +13,7 @@ from crawler.base import ImageJobDetail, JobDetail, JobListingRef
 from crawler.registry import get_crawler, iter_sources
 from embedding import build_document, embed_text
 from ocr_client import call_ocr
-from parser.jobkorea import _remove_noise_sections
+from parser.jobkorea import remove_noise_sections
 from storage.s3 import S3Storage
 
 logger = logging.getLogger(__name__)
@@ -153,7 +153,7 @@ def _process_image_jd(
         logger.info("OCR 결과 비어있음, 스킵: id=%s", image_detail.external_id)
         return None
 
-    cleaned = _remove_noise_sections(raw_text)
+    cleaned = remove_noise_sections(raw_text)
     if not cleaned:
         logger.info("OCR 노이즈 제거 후 텍스트 없음, 스킵: id=%s", image_detail.external_id)
         return None

--- a/src/crawler/base.py
+++ b/src/crawler/base.py
@@ -35,6 +35,21 @@ class JobDetail:
     career_level: str = ""
 
 
+@dataclass(frozen=True)
+class ImageJobDetail:
+    """이미지 JD. OCR 처리 후 JobDetail 로 변환 필요."""
+    source: str
+    external_id: str
+    url: str
+    company_name: str
+    title: str
+    images_b64: tuple[str, ...]
+    tech_stack: tuple[str, ...]
+    deadline: str
+    crawled_at: str
+    career_level: str = ""
+
+
 DEFAULT_DELAY_MIN = 1.0
 DEFAULT_DELAY_MAX = 2.5
 DEFAULT_MAX_PAGES = 500
@@ -63,7 +78,7 @@ class JobCrawler(ABC):
     def fetch_listings_page(self, page: int) -> list[JobListingRef]: ...
 
     @abstractmethod
-    def fetch_detail(self, ref: JobListingRef) -> JobDetail | None: ...
+    def fetch_detail(self, ref: JobListingRef) -> JobDetail | ImageJobDetail | None: ...
 
     def collect_listings(self) -> list[JobListingRef]:
         """전체 목록 페이지를 순회해 공고를 모은다. stale 감지로 조기 종료."""

--- a/src/crawler/jobkorea.py
+++ b/src/crawler/jobkorea.py
@@ -1,4 +1,5 @@
 """잡코리아 크롤러. 동작 파라미터는 JOBKOREA_* 환경변수로 오버라이드 가능."""
+import base64
 import logging
 import os
 import random
@@ -12,11 +13,17 @@ from crawler.base import (
     DEFAULT_DELAY_MIN,
     DEFAULT_MAX_PAGES,
     DEFAULT_STALE_PAGE_THRESHOLD,
+    ImageJobDetail,
     JobCrawler,
     JobDetail,
     JobListingRef,
 )
-from parser.jobkorea import parse_job_detail, parse_job_iframe, parse_job_list
+from parser.jobkorea import (
+    extract_iframe_image_urls,
+    parse_job_detail,
+    parse_job_iframe,
+    parse_job_list,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -133,7 +140,7 @@ class JobKoreaCrawler(JobCrawler):
             for item in parse_job_list(resp.text)
         ]
 
-    def fetch_detail(self, ref: JobListingRef) -> JobDetail | None:
+    def fetch_detail(self, ref: JobListingRef) -> JobDetail | ImageJobDetail | None:
         # 상세 페이지 → 메타데이터 (회사명, 제목, 마감일, 기술스택)
         detail_resp = self.session.get(ref.url, timeout=15)
         detail_resp.raise_for_status()
@@ -146,22 +153,56 @@ class JobKoreaCrawler(JobCrawler):
         iframe_resp.raise_for_status()
         raw_text = parse_job_iframe(iframe_resp.text)
 
-        if raw_text is None:
-            logger.info("external_id=%s: 이미지 JD, 스킵", ref.external_id)
+        if raw_text is not None:
+            return JobDetail(
+                source=self.source,
+                external_id=ref.external_id,
+                url=ref.url,
+                company_name=metadata.company_name or ref.company_name,
+                title=metadata.title or ref.title,
+                raw_text=raw_text,
+                tech_stack=metadata.tech_stack,
+                deadline=metadata.deadline,
+                crawled_at=datetime.now(KST).isoformat(),
+                career_level=ref.career_level,
+            )
+
+        # 이미지 JD: 이미지 다운로드 → ImageJobDetail 반환
+        image_urls = extract_iframe_image_urls(iframe_resp.text)
+        if not image_urls:
+            logger.info("external_id=%s: 텍스트·이미지 모두 없음, 스킵", ref.external_id)
             return None
 
-        return JobDetail(
+        images_b64 = self._download_images(image_urls)
+        if not images_b64:
+            logger.info("external_id=%s: 이미지 다운로드 실패, 스킵", ref.external_id)
+            return None
+
+        logger.info("external_id=%s: 이미지 JD %d장 추출", ref.external_id, len(images_b64))
+        return ImageJobDetail(
             source=self.source,
             external_id=ref.external_id,
             url=ref.url,
             company_name=metadata.company_name or ref.company_name,
             title=metadata.title or ref.title,
-            raw_text=raw_text,
+            images_b64=tuple(images_b64),
             tech_stack=metadata.tech_stack,
             deadline=metadata.deadline,
             crawled_at=datetime.now(KST).isoformat(),
             career_level=ref.career_level,
         )
+
+    def _download_images(self, urls: list[str]) -> list[str]:
+        """이미지 URL 목록을 다운로드하여 base64 인코딩된 리스트로 반환."""
+        results: list[str] = []
+        for url in urls:
+            try:
+                resp = self.session.get(url, timeout=15)
+                resp.raise_for_status()
+                results.append(base64.b64encode(resp.content).decode("ascii"))
+            except Exception:
+                logger.warning("이미지 다운로드 실패: %s", url, exc_info=True)
+        return results
 
 
 _T = TypeVar("_T")

--- a/src/ocr_client.py
+++ b/src/ocr_client.py
@@ -1,0 +1,34 @@
+"""OCR 서버 HTTP 클라이언트. Lambda 에서 EC2 OCR 서버를 호출한다."""
+import logging
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+OCR_TIMEOUT = 30
+
+
+def call_ocr(images_b64: list[str], server_url: str, api_key: str = "") -> str:
+    """이미지 목록을 OCR 서버에 전송하여 텍스트를 추출.
+
+    각 이미지의 OCR 결과를 줄바꿈으로 합산하여 반환한다.
+    서버 오류 시 예외를 전파하여 SQS 재시도(DLQ) 로 넘긴다.
+    """
+    endpoint = f"{server_url.rstrip('/')}/ocr"
+    headers = {"X-API-Key": api_key} if api_key else {}
+    texts: list[str] = []
+
+    for i, img_b64 in enumerate(images_b64):
+        resp = requests.post(
+            endpoint,
+            json={"image_b64": img_b64},
+            headers=headers,
+            timeout=OCR_TIMEOUT,
+        )
+        resp.raise_for_status()
+        text = resp.json().get("text", "")
+        if text:
+            texts.append(text)
+        logger.info("OCR 이미지 %d/%d 완료: %d자", i + 1, len(images_b64), len(text))
+
+    return "\n".join(texts)

--- a/src/parser/jobkorea.py
+++ b/src/parser/jobkorea.py
@@ -83,7 +83,7 @@ def parse_job_iframe(html: str) -> str | None:
     if not text:
         return None
 
-    cleaned = _remove_noise_sections(text)
+    cleaned = remove_noise_sections(text)
     return cleaned or None
 
 
@@ -154,7 +154,7 @@ _NOISE_SECTION_HEADERS: frozenset[str] = frozenset({
 })
 
 
-def _remove_noise_sections(text: str) -> str:
+def remove_noise_sections(text: str) -> str:
     """기업소개·복리후생·전형절차 등 노이즈 섹션을 제거.
 
     1) JD 본문 시작 키워드(모집분야/담당업무 등)를 찾아 그 앞의 상단 노이즈를 제거한다.

--- a/src/parser/jobkorea.py
+++ b/src/parser/jobkorea.py
@@ -1,6 +1,7 @@
 """잡코리아 HTML 파서 — 목록 / 상세 메타(__next_f) / iframe JD 텍스트 추출."""
 import re
 from dataclasses import dataclass
+from urllib.parse import urljoin
 
 from bs4 import BeautifulSoup
 
@@ -84,6 +85,47 @@ def parse_job_iframe(html: str) -> str | None:
 
     cleaned = _remove_noise_sections(text)
     return cleaned or None
+
+
+_IFRAME_BASE_URL = "https://www.jobkorea.co.kr/Recruit/GI_Read_Comt_Ifrm"
+
+# 로고·아이콘 등 JD 본문과 무관한 작은 이미지를 걸러내는 최소 크기 (px).
+_MIN_IMAGE_DIMENSION = 50
+
+
+def extract_iframe_image_urls(html: str) -> list[str]:
+    """iframe HTML 에서 JD 본문 이미지 URL 을 추출.
+
+    data: URI, 너무 작은 이미지(로고·아이콘)는 제외한다.
+    상대 경로는 잡코리아 iframe base URL 기준으로 절대 경로로 변환한다.
+    """
+    soup = BeautifulSoup(html, "html.parser")
+    urls: list[str] = []
+
+    for img in soup.find_all("img"):
+        src = img.get("src", "")
+        if not src or src.startswith("data:"):
+            continue
+
+        if _is_small_image(img):
+            continue
+
+        absolute_url = urljoin(_IFRAME_BASE_URL, src)
+        urls.append(absolute_url)
+
+    return urls
+
+
+def _is_small_image(img) -> bool:
+    """width 또는 height 속성이 명시되어 있고 _MIN_IMAGE_DIMENSION 미만이면 True."""
+    for attr in ("width", "height"):
+        val = img.get(attr, "")
+        try:
+            if int(val) < _MIN_IMAGE_DIMENSION:
+                return True
+        except (ValueError, TypeError):
+            continue
+    return False
 
 
 # ── 내부 헬퍼 ──

--- a/template.yaml
+++ b/template.yaml
@@ -13,6 +13,15 @@ Parameters:
     Description: DLQ 알람 Discord 웹훅 URL
     NoEcho: true
     Default: ''
+  OcrServerUrl:
+    Type: String
+    Description: OCR 서버 URL (이미지 JD 처리용, 미설정 시 이미지 JD 스킵)
+    Default: ''
+  OcrApiKey:
+    Type: String
+    Description: OCR 서버 API 키 (X-API-Key 인증)
+    NoEcho: true
+    Default: ''
 
 Globals:
   Function:
@@ -130,6 +139,10 @@ Resources:
       PackageType: Image
       Timeout: 120
       MemorySize: 1024
+      Environment:
+        Variables:
+          OCR_SERVER_URL: !Ref OcrServerUrl
+          OCR_API_KEY: !Ref OcrApiKey
       Policies:
         - S3CrudPolicy:
             BucketName: !Ref CrawlerDataBucket

--- a/tests/unit/test_handler.py
+++ b/tests/unit/test_handler.py
@@ -12,7 +12,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 import app
-from crawler.base import JobDetail, JobListingRef
+from crawler.base import ImageJobDetail, JobDetail, JobListingRef
 
 
 # ─────────────────────────────────────────────────────────
@@ -261,3 +261,117 @@ def test_job_detail_crawler_reraises_on_failure(mock_get_crawler, mock_storage_c
 
     with pytest.raises(RuntimeError, match="boom"):
         app.job_detail_crawler(event, None)
+
+
+# ─────────────────────────────────────────────────────────
+# job_detail_crawler — 이미지 JD OCR 처리
+# ─────────────────────────────────────────────────────────
+
+
+def _image_detail(**overrides) -> ImageJobDetail:
+    base = dict(
+        source="jobkorea",
+        external_id="888",
+        url="https://www.jobkorea.co.kr/Recruit/GI_Read/888",
+        company_name="이미지기업",
+        title="프론트엔드 채용",
+        images_b64=("aW1hZ2VkYXRh",),
+        tech_stack=("React",),
+        deadline="2026-05-01T23:59:59+09:00",
+        crawled_at="2026-04-11T18:00:00+09:00",
+    )
+    base.update(overrides)
+    return ImageJobDetail(**base)
+
+
+@patch("app.embed_text", return_value=[0.1] * 768)
+@patch("app.call_ocr", return_value="담당업무\n프론트엔드 개발\n자격요건\nReact 경험")
+@patch("app.S3Storage")
+@patch("app.get_crawler")
+def test_image_jd_ocr_saves_detail(
+    mock_get_crawler, mock_storage_cls, mock_ocr, mock_embed, monkeypatch,
+):
+    """이미지 JD 가 OCR 처리되어 JobDetail 로 저장된다."""
+    monkeypatch.setenv("OCR_SERVER_URL", "http://ocr:8500")
+    monkeypatch.setenv("OCR_API_KEY", "test-key")
+    mock_storage = MagicMock()
+    mock_storage_cls.return_value = mock_storage
+
+    mock_crawler = MagicMock()
+    mock_crawler.fetch_detail.return_value = _image_detail()
+    mock_get_crawler.return_value = mock_crawler
+
+    event = _make_sqs_event({
+        "source": "jobkorea",
+        "external_id": "888",
+        "url": "https://www.jobkorea.co.kr/Recruit/GI_Read/888",
+        "company_name": "이미지기업",
+        "title": "프론트엔드 채용",
+    })
+    app.job_detail_crawler(event, None)
+
+    mock_ocr.assert_called_once()
+    _, kwargs = mock_ocr.call_args
+    # 없으면 positional 으로 확인
+    call_args = mock_ocr.call_args
+    assert call_args[0][2] == "test-key"  # api_key 전달 검증
+    mock_storage.save.assert_called_once()
+    saved = mock_storage.save.call_args.args[0]
+    assert isinstance(saved, JobDetail)
+    assert "프론트엔드 개발" in saved.raw_text
+
+
+@patch("app.call_ocr")
+@patch("app.S3Storage")
+@patch("app.get_crawler")
+def test_image_jd_skipped_when_no_ocr_url(
+    mock_get_crawler, mock_storage_cls, mock_ocr, monkeypatch,
+):
+    """OCR_SERVER_URL 이 미설정이면 이미지 JD 를 스킵한다."""
+    monkeypatch.delenv("OCR_SERVER_URL", raising=False)
+    mock_storage = MagicMock()
+    mock_storage_cls.return_value = mock_storage
+
+    mock_crawler = MagicMock()
+    mock_crawler.fetch_detail.return_value = _image_detail()
+    mock_get_crawler.return_value = mock_crawler
+
+    event = _make_sqs_event({
+        "source": "jobkorea",
+        "external_id": "888",
+        "url": "https://www.jobkorea.co.kr/Recruit/GI_Read/888",
+        "company_name": "이미지기업",
+        "title": "프론트엔드 채용",
+    })
+    app.job_detail_crawler(event, None)
+
+    mock_ocr.assert_not_called()
+    mock_storage.save.assert_not_called()
+
+
+@patch("app.embed_text", return_value=[0.1] * 768)
+@patch("app.call_ocr", return_value="")
+@patch("app.S3Storage")
+@patch("app.get_crawler")
+def test_image_jd_skipped_when_ocr_empty(
+    mock_get_crawler, mock_storage_cls, mock_ocr, mock_embed, monkeypatch,
+):
+    """OCR 결과가 비어있으면 저장하지 않고 스킵한다."""
+    monkeypatch.setenv("OCR_SERVER_URL", "http://ocr:8500")
+    mock_storage = MagicMock()
+    mock_storage_cls.return_value = mock_storage
+
+    mock_crawler = MagicMock()
+    mock_crawler.fetch_detail.return_value = _image_detail()
+    mock_get_crawler.return_value = mock_crawler
+
+    event = _make_sqs_event({
+        "source": "jobkorea",
+        "external_id": "888",
+        "url": "https://www.jobkorea.co.kr/Recruit/GI_Read/888",
+        "company_name": "이미지기업",
+        "title": "프론트엔드 채용",
+    })
+    app.job_detail_crawler(event, None)
+
+    mock_storage.save.assert_not_called()

--- a/tests/unit/test_ocr_client.py
+++ b/tests/unit/test_ocr_client.py
@@ -1,0 +1,128 @@
+"""ocr_client 단위 테스트. 외부 HTTP 호출은 mock 으로 대체한다."""
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ocr_client import call_ocr
+
+
+@patch("ocr_client.requests.post")
+def test_single_image_returns_text(mock_post):
+    """이미지 1장 전송 시 OCR 결과 텍스트를 반환한다."""
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = {"text": "주요업무\n백엔드 개발"}
+    mock_post.return_value = mock_resp
+
+    result = call_ocr(["base64data"], "http://ocr:8500")
+
+    assert result == "주요업무\n백엔드 개발"
+    mock_post.assert_called_once_with(
+        "http://ocr:8500/ocr",
+        json={"image_b64": "base64data"},
+        headers={},
+        timeout=30,
+    )
+
+
+@patch("ocr_client.requests.post")
+def test_multiple_images_concatenated(mock_post):
+    """여러 이미지의 OCR 결과가 줄바꿈으로 합산된다."""
+    resp1 = MagicMock()
+    resp1.json.return_value = {"text": "모집분야"}
+    resp2 = MagicMock()
+    resp2.json.return_value = {"text": "자격요건"}
+    mock_post.side_effect = [resp1, resp2]
+
+    result = call_ocr(["img1", "img2"], "http://ocr:8500")
+
+    assert result == "모집분야\n자격요건"
+    assert mock_post.call_count == 2
+
+
+@patch("ocr_client.requests.post")
+def test_empty_ocr_result_skipped(mock_post):
+    """OCR 결과가 빈 문자열이면 합산에서 제외된다."""
+    resp1 = MagicMock()
+    resp1.json.return_value = {"text": ""}
+    resp2 = MagicMock()
+    resp2.json.return_value = {"text": "자격요건"}
+    mock_post.side_effect = [resp1, resp2]
+
+    result = call_ocr(["img1", "img2"], "http://ocr:8500")
+
+    assert result == "자격요건"
+
+
+@patch("ocr_client.requests.post")
+def test_all_empty_returns_empty_string(mock_post):
+    """모든 OCR 결과가 비면 빈 문자열을 반환한다."""
+    resp = MagicMock()
+    resp.json.return_value = {"text": ""}
+    mock_post.return_value = resp
+
+    result = call_ocr(["img1"], "http://ocr:8500")
+
+    assert result == ""
+
+
+@patch("ocr_client.requests.post")
+def test_server_error_propagates(mock_post):
+    """OCR 서버 오류 시 예외가 전파된다."""
+    mock_resp = MagicMock()
+    mock_resp.raise_for_status.side_effect = Exception("500 Server Error")
+    mock_post.return_value = mock_resp
+
+    with pytest.raises(Exception, match="500 Server Error"):
+        call_ocr(["img1"], "http://ocr:8500")
+
+
+@patch("ocr_client.requests.post")
+def test_trailing_slash_handled(mock_post):
+    """server_url 끝에 슬래시가 있어도 정상 동작한다."""
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = {"text": "결과"}
+    mock_post.return_value = mock_resp
+
+    call_ocr(["img1"], "http://ocr:8500/")
+
+    mock_post.assert_called_once_with(
+        "http://ocr:8500/ocr",
+        json={"image_b64": "img1"},
+        headers={},
+        timeout=30,
+    )
+
+
+@patch("ocr_client.requests.post")
+def test_api_key_sent_in_header(mock_post):
+    """api_key 가 설정되면 X-API-Key 헤더에 포함된다."""
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = {"text": "결과"}
+    mock_post.return_value = mock_resp
+
+    call_ocr(["img1"], "http://ocr:8500", api_key="secret-123")
+
+    mock_post.assert_called_once_with(
+        "http://ocr:8500/ocr",
+        json={"image_b64": "img1"},
+        headers={"X-API-Key": "secret-123"},
+        timeout=30,
+    )
+
+
+@patch("ocr_client.requests.post")
+def test_no_api_key_sends_no_header(mock_post):
+    """api_key 가 빈 문자열이면 X-API-Key 헤더를 보내지 않는다."""
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = {"text": "결과"}
+    mock_post.return_value = mock_resp
+
+    call_ocr(["img1"], "http://ocr:8500", api_key="")
+
+    mock_post.assert_called_once_with(
+        "http://ocr:8500/ocr",
+        json={"image_b64": "img1"},
+        headers={},
+        timeout=30,
+    )

--- a/tests/unit/test_parser_jobkorea.py
+++ b/tests/unit/test_parser_jobkorea.py
@@ -1,8 +1,9 @@
-"""parser.jobkorea 단위 테스트 — tech_stack 필터링 및 raw_text 노이즈 제거."""
+"""parser.jobkorea 단위 테스트 — tech_stack 필터링, raw_text 노이즈 제거, 이미지 URL 추출."""
 from parser.jobkorea import (
     _extract_tech_stack,
     _is_non_tech_skill,
     _remove_noise_sections,
+    extract_iframe_image_urls,
     parse_job_iframe,
 )
 
@@ -221,3 +222,52 @@ class TestParseJobIframe:
         html = "<html><body></body></html>"
         result = parse_job_iframe(html)
         assert result is None
+
+
+class TestExtractIframeImageUrls:
+    """iframe 이미지 URL 추출."""
+
+    def test_extracts_absolute_urls(self):
+        html = '<html><body><img src="https://cdn.jobkorea.co.kr/jd/1.png"></body></html>'
+        result = extract_iframe_image_urls(html)
+        assert result == ["https://cdn.jobkorea.co.kr/jd/1.png"]
+
+    def test_converts_relative_urls(self):
+        html = '<html><body><img src="/images/jd.png"></body></html>'
+        result = extract_iframe_image_urls(html)
+        assert result == ["https://www.jobkorea.co.kr/images/jd.png"]
+
+    def test_skips_data_uri(self):
+        html = '<html><body><img src="data:image/png;base64,abc"></body></html>'
+        result = extract_iframe_image_urls(html)
+        assert result == []
+
+    def test_skips_small_images(self):
+        html = '<html><body><img src="https://cdn.jobkorea.co.kr/logo.png" width="30" height="30"></body></html>'
+        result = extract_iframe_image_urls(html)
+        assert result == []
+
+    def test_keeps_large_images(self):
+        html = '<html><body><img src="https://cdn.jobkorea.co.kr/jd.png" width="800" height="600"></body></html>'
+        result = extract_iframe_image_urls(html)
+        assert len(result) == 1
+
+    def test_keeps_images_without_dimensions(self):
+        html = '<html><body><img src="https://cdn.jobkorea.co.kr/jd.png"></body></html>'
+        result = extract_iframe_image_urls(html)
+        assert len(result) == 1
+
+    def test_skips_empty_src(self):
+        html = '<html><body><img src=""><img></body></html>'
+        result = extract_iframe_image_urls(html)
+        assert result == []
+
+    def test_multiple_images(self):
+        html = (
+            '<html><body>'
+            '<img src="https://cdn.jobkorea.co.kr/1.png">'
+            '<img src="https://cdn.jobkorea.co.kr/2.png">'
+            '</body></html>'
+        )
+        result = extract_iframe_image_urls(html)
+        assert len(result) == 2

--- a/tests/unit/test_parser_jobkorea.py
+++ b/tests/unit/test_parser_jobkorea.py
@@ -2,7 +2,7 @@
 from parser.jobkorea import (
     _extract_tech_stack,
     _is_non_tech_skill,
-    _remove_noise_sections,
+    remove_noise_sections,
     extract_iframe_image_urls,
     parse_job_iframe,
 )
@@ -92,7 +92,7 @@ class TestRemoveNoiseSections:
             "4대 보험\n"
             "명절선물\n"
         )
-        result = _remove_noise_sections(text)
+        result = remove_noise_sections(text)
         assert "백엔드 서버 개발" in result
         assert "Python 3년 이상" in result
         assert "복리후생" not in result
@@ -106,7 +106,7 @@ class TestRemoveNoiseSections:
             "서류전형\n"
             "면접\n"
         )
-        result = _remove_noise_sections(text)
+        result = remove_noise_sections(text)
         assert "서비스 개발" in result
         assert "전형절차" not in result
         assert "서류전형" not in result
@@ -118,18 +118,18 @@ class TestRemoveNoiseSections:
             "접수기간 및 방법\n"
             "채용 시 마감\n"
         )
-        result = _remove_noise_sections(text)
+        result = remove_noise_sections(text)
         assert "AWS 경험" in result
         assert "접수기간" not in result
 
     def test_no_noise_returns_original(self):
         text = "담당업무\n서비스 개발\n자격요건\nPython"
-        result = _remove_noise_sections(text)
+        result = remove_noise_sections(text)
         assert result == text
 
     def test_empty_after_noise_removal(self):
         text = "복리후생\n4대 보험"
-        result = _remove_noise_sections(text)
+        result = remove_noise_sections(text)
         assert result == ""
 
     def test_first_noise_header_wins(self):
@@ -141,7 +141,7 @@ class TestRemoveNoiseSections:
             "전형절차\n"
             "면접\n"
         )
-        result = _remove_noise_sections(text)
+        result = remove_noise_sections(text)
         assert "개발" in result
         assert "복리후생" not in result
         assert "전형절차" not in result
@@ -156,7 +156,7 @@ class TestRemoveNoiseSections:
             "자격요건\n"
             "Python 3년\n"
         )
-        result = _remove_noise_sections(text)
+        result = remove_noise_sections(text)
         assert "기업 개요" not in result
         assert "업력 9년차" not in result
         assert "모집분야" in result
@@ -175,7 +175,7 @@ class TestRemoveNoiseSections:
             "전형절차\n"
             "면접\n"
         )
-        result = _remove_noise_sections(text)
+        result = remove_noise_sections(text)
         assert "회사명" not in result
         assert "설립일" not in result
         assert "담당업무" in result
@@ -190,7 +190,7 @@ class TestRemoveNoiseSections:
             "복리후생\n"
             "4대 보험\n"
         )
-        result = _remove_noise_sections(text)
+        result = remove_noise_sections(text)
         assert "백엔드 개발자 모집" in result
         assert "Python 경험 필수" in result
         assert "복리후생" not in result


### PR DESCRIPTION
## #️⃣ 연관된 이슈

Refs #31

---

## #️⃣ 작업 내용

이미지로 된 채용공고(JD)를 OCR로 텍스트 변환하여 크롤링 커버리지를 확대한다.

### 변경 전 — 이미지 JD 전량 스킵

```
잡코리아 iframe
    │
    ▼
parse_job_iframe()
    │
    ├── 텍스트 JD (100자 이상) → raw_text 추출 → JobDetail → 임베딩 → S3 저장 ✅
    │
    └── 이미지 JD (100자 미만 + <img> 존재) → None 반환 → 스킵 ❌
```

이미지로 된 JD는 텍스트 추출이 불가능하여 전량 스킵되었다.
상당수의 채용공고가 JD를 이미지로 게시하므로, 벡터 DB에 저장되는 공고 수가 줄어들어 JD 매칭 풀이 작아지는 문제가 있었다.

### 변경 후 — OCR 서버 연동

```
잡코리아 iframe
    │
    ▼
parse_job_iframe()
    │
    ├── 텍스트 JD (100자 이상) → raw_text 추출 → JobDetail (기존과 동일)
    │
    └── 이미지 JD (100자 미만 + <img> 존재)
            │
            ▼
        extract_iframe_image_urls()      ← 이미지 URL 추출 (data: URI, 소형 이미지 제외)
            │
            ▼
        _download_images()               ← 이미지 다운로드 + base64 인코딩
            │
            ▼
        ImageJobDetail 반환              ← raw_text 대신 images_b64 필드
            │
            ▼
    job_detail_crawler 핸들러
            │
            ▼
        _process_image_jd()
            │
            ▼
        call_ocr()                       ← OCR 서버 HTTP POST (X-API-Key 인증)
            │
            ▼
        _remove_noise_sections()         ← 노이즈 제거 (기존 텍스트 JD와 동일 로직 재사용)
            │
            ▼
        JobDetail 생성 → 임베딩 → S3 저장 ✅
```

---

### 설계 근거

#### 1. OCR 서버를 EC2에 별도 컨테이너로 분리

```
┌─────────────────────────────────── EC2 (t3.micro) ───────────────────────────────────┐
│                                                                                       │
│   ┌──────────────┐    ┌──────────────┐    ┌──────────────┐                           │
│   │   ChromaDB   │    │   Consumer   │    │  OCR 서버    │                           │
│   │   (8000)     │    │  S3 → Chroma │    │  (8500)      │                           │
│   │              │◄───│              │    │  PaddleOCR   │                           │
│   └──────────────┘    └──────────────┘    └──────▲───────┘                           │
│        Docker 네트워크 (내부 통신)                │                                    │
└──────────────────────────────────────────────────┼────────────────────────────────────┘
                                                   │ HTTP POST /ocr
                                                   │ (X-API-Key 인증)
                                              ┌────┴────┐
                                              │ Lambda  │  ← VPC 밖
                                              │ (크롤러) │
                                              └─────────┘
```

- **비용 최소화**: 기존 ChromaDB EC2에 컨테이너를 추가하므로 인프라 비용 증가 없음.
- **PaddleOCR 한국어 지원**: 별도 모델 학습 없이 한국어 텍스트 추출 가능. Dockerfile에서 한국어 모델을 미리 다운로드하여 콜드스타트 제거.
- **하위호환**: `OCR_SERVER_URL` 미설정 시 이미지 JD를 기존처럼 스킵. OCR 서버 배포 전에도 크롤러 정상 동작.

#### 2. Lambda에서 직접 OCR을 실행하지 않는 이유

PaddleOCR + 한국어 모델은 약 1GB 이상의 의존성과 메모리를 요구한다.
현재 `job_detail_crawler` Lambda(1024MB)는 ONNX 임베딩 모델로 이미 메모리 여유가 적고, Lambda 컨테이너 이미지에 OCR 모델까지 포함하면 이미지 크기와 콜드스타트가 급증한다.
EC2에서 상주 프로세스로 운영하면 모델 로드가 1회뿐이라 응답 속도도 빠르다.

#### 3. API 키 인증을 추가한 이유

Lambda가 VPC 밖에서 OCR 서버를 호출하므로 EC2 보안그룹에서 Lambda IP 대역을 열어야 한다.
네트워크 레벨 보안만으로는 불충분하므로 `X-API-Key` 헤더 인증으로 이중 보안을 확보한다.
`OCR_API_KEY` 미설정 시 인증 비활성화로 로컬 개발 편의성 유지.

#### 4. ImageJobDetail을 별도 dataclass로 분리한 이유

```
                    fetch_detail() 반환 타입
                            │
               ┌────────────┼────────────┐
               ▼            ▼            ▼
          JobDetail   ImageJobDetail    None
          (텍스트)     (이미지)        (스킵)
               │            │
               │            ▼
               │     _process_image_jd()
               │            │
               │            ▼
               │       OCR → JobDetail
               │            │
               ▼            ▼
          build_document + embed_text → S3 저장
```

`JobDetail`에 `images_b64` 필드를 추가하면 `raw_text`와 `images_b64` 중 어느 것이 유효한지 런타임에 판단해야 한다.
`ImageJobDetail`을 별도 frozen dataclass로 분리하면 타입만으로 텍스트/이미지 JD를 구분할 수 있고, `isinstance` 분기로 각 경로를 명확하게 처리할 수 있다.

#### 5. OCR 실패 시 재시도 전략

OCR 서버 오류 시 예외를 전파하여 SQS 재시도 → DLQ로 넘긴다.
이미지 JD 1건의 OCR 실패가 전체 파이프라인을 중단시키지 않으며, DLQ에 쌓인 메시지는 Discord 알림(기존 구현)으로 즉시 인지할 수 있다.

---

## #️⃣ 테스트 결과

### 신규 테스트

| 파일 | 테스트 수 | 내용 |
|------|-----------|------|
| `test_ocr_client.py` | 8개 | HTTP 호출 mock, 다중 이미지 합산, 빈 결과 처리, API 키 헤더, 서버 오류 전파 |
| `test_handler.py` (추가) | 3개 | 이미지 JD OCR 저장, OCR_SERVER_URL 미설정 시 스킵, OCR 결과 비어있을 때 스킵 |
| `test_parser_jobkorea.py` (추가) | 8개 | 절대/상대 URL, data: URI 제외, 소형 이미지 제외, 빈 src 처리, 복수 이미지 |

```
$ python -m pytest tests/unit/ -v
========================= 모든 테스트 통과 =========================
```

---

## #️⃣ 변경 사항 체크리스트

- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [x] 문서를 작성하거나 수정했나요? (필요한 경우)
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

---

## #️⃣ 리뷰 요구사항

1. **`_process_image_jd` 분기 처리**: `isinstance(result, ImageJobDetail)` 분기가 기존 텍스트 JD 경로에 영향을 주지 않는지 확인 부탁드립니다.
2. **OCR 실패 시 재시도 전략**: OCR 서버 오류 시 예외 전파 → SQS 재시도(→ DLQ) 전략이 적절한지 의견 부탁드립니다.

---

## 📎 참고 자료

- [PaddleOCR 한국어 모델](https://github.com/PaddlePaddle/PaddleOCR)
- OCR 서버 구현: `ocr/ocr_server.py` (기존 커밋 `b207932`에서 추가, 이번 PR에서 API 키 인증 보강)