### PR TITLE
fix: ocr-builder 스테이지에 packaging 의존성 추가

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -28,7 +28,7 @@ FROM python:3.11-slim AS ocr-builder
 RUN apt-get update && apt-get install -y --no-install-recommends wget \
     && rm -rf /var/lib/apt/lists/*
 
-RUN pip install --no-cache-dir paddlepaddle==2.6.2 paddle2onnx
+RUN pip install --no-cache-dir paddlepaddle==2.6.2 paddle2onnx packaging
 
 # 한국어 PP-OCRv3 rec 모델 다운로드 및 변환
 RUN wget -q https://paddleocr.bj.bcebos.com/PP-OCRv3/multilingual/korean_PP-OCRv3_rec_infer.tar \


### PR DESCRIPTION
paddle2onnx 2.1.0이 packaging 모듈을 import하지만
명시적 의존성으로 설치하지 않아 빌드 실패하던 문제 수정

## #️⃣ 연관된 이슈

> #33 

## #️⃣ 작업 내용

- paddle2onnx에 packaging 모듈 의존성이 누락되어 빌드 과정에서 에러 발생. Dockerfile에 추가

## #️⃣ 변경 사항 체크리스트

- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [x] 문서를 작성하거나 수정했나요? (필요한 경우)
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?