### PR TITLE
fix: ocr-builder 스테이지에 libgomp1 의존성 추가

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -25,7 +25,7 @@ t.save_pretrained('/tmp/tokenizer/')"
 # Stage 2: PaddleOCR 한국어 모델 → ONNX 변환
 FROM python:3.11-slim AS ocr-builder
 
-RUN apt-get update && apt-get install -y --no-install-recommends wget \
+RUN apt-get update && apt-get install -y --no-install-recommends wget libgomp1 \
     && rm -rf /var/lib/apt/lists/*
 
 RUN pip install --no-cache-dir paddlepaddle==2.6.2 paddle2onnx packaging


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #33 

## #️⃣ 작업 내용

PaddlePaddle이 libgomp.so.1(OpenMP)을 필요로 하는데
python:3.11-slim에 미포함되어 paddle2onnx 변환 실패하던 문제 수정


## #️⃣ 변경 사항 체크리스트

- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [x] 문서를 작성하거나 수정했나요? (필요한 경우)
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [ ] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?