### PR TITLE
fix: SAM 배포 실패 해결 (paddle2onnx 호환성 + zip Lambda 250MB 초과)

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -61,7 +61,7 @@ COPY --from=ocr-builder /tmp/ocr_models/korean_rec.onnx /app/ocr_models/korean_r
 COPY --from=ocr-builder /tmp/ocr_models/korean_dict.txt /app/ocr_models/korean_dict.txt
 
 # 의존성 설치
-COPY src/requirements.txt ${LAMBDA_TASK_ROOT}/
+COPY src/requirements-full.txt ${LAMBDA_TASK_ROOT}/requirements.txt
 RUN pip install --no-cache-dir -r ${LAMBDA_TASK_ROOT}/requirements.txt
 
 # 소스 코드 복사

--- a/src/app.py
+++ b/src/app.py
@@ -11,9 +11,6 @@ import boto3
 
 from crawler.base import ImageJobDetail, JobDetail, JobListingRef
 from crawler.registry import get_crawler, iter_sources
-from embedding import build_document, embed_text
-from ocr_client import call_ocr
-from parser.jobkorea import remove_noise_sections
 from storage.s3 import S3Storage
 
 logger = logging.getLogger(__name__)
@@ -100,6 +97,8 @@ def _dispatch_new_listings(
 
 def job_detail_crawler(event, context):
     """SQS 트리거. 공고 1건 상세 크롤링 → S3 저장."""
+    from embedding import build_document, embed_text  # noqa: C0415
+
     storage = _make_storage()
 
     for record in event["Records"]:
@@ -140,6 +139,9 @@ def job_detail_crawler(event, context):
 
 def _process_image_jd(image_detail: ImageJobDetail) -> JobDetail | None:
     """이미지 JD 를 로컬 ONNX OCR 로 처리하여 JobDetail 로 변환."""
+    from ocr_client import call_ocr  # noqa: C0415
+    from parser.jobkorea import remove_noise_sections  # noqa: C0415
+
     raw_text = call_ocr(list(image_detail.images_b64))
     if not raw_text.strip():
         logger.info("OCR 결과 비어있음, 스킵: id=%s", image_detail.external_id)

--- a/src/requirements-full.txt
+++ b/src/requirements-full.txt
@@ -1,0 +1,7 @@
+requests
+beautifulsoup4
+onnxruntime
+transformers
+numpy<2
+rapidocr-onnxruntime
+Pillow

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,7 +1,2 @@
 requests
 beautifulsoup4
-onnxruntime
-transformers
-numpy<2
-rapidocr-onnxruntime
-Pillow

--- a/tests/unit/test_handler.py
+++ b/tests/unit/test_handler.py
@@ -187,7 +187,7 @@ def test_job_list_collector_fails_fast_when_queue_url_missing(
 # ─────────────────────────────────────────────────────────
 
 
-@patch("app.embed_text", return_value=[0.1] * 768)
+@patch("embedding.embed_text", return_value=[0.1] * 768)
 @patch("app.S3Storage")
 @patch("app.get_crawler")
 def test_job_detail_crawler_saves_fetched_detail(
@@ -284,8 +284,8 @@ def _image_detail(**overrides) -> ImageJobDetail:
     return ImageJobDetail(**base)
 
 
-@patch("app.embed_text", return_value=[0.1] * 768)
-@patch("app.call_ocr", return_value="담당업무\n프론트엔드 개발\n자격요건\nReact 경험")
+@patch("embedding.embed_text", return_value=[0.1] * 768)
+@patch("ocr_client.call_ocr", return_value="담당업무\n프론트엔드 개발\n자격요건\nReact 경험")
 @patch("app.S3Storage")
 @patch("app.get_crawler")
 def test_image_jd_ocr_saves_detail(
@@ -315,8 +315,8 @@ def test_image_jd_ocr_saves_detail(
     assert "프론트엔드 개발" in saved.raw_text
 
 
-@patch("app.embed_text", return_value=[0.1] * 768)
-@patch("app.call_ocr", return_value="")
+@patch("embedding.embed_text", return_value=[0.1] * 768)
+@patch("ocr_client.call_ocr", return_value="")
 @patch("app.S3Storage")
 @patch("app.get_crawler")
 def test_image_jd_skipped_when_ocr_empty(


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#37

## #️⃣ 작업 내용

1. **paddle2onnx 버전 고정**: ocr-builder 스테이지에서 `paddle2onnx`를 `>=1.2,<2.0`으로 고정하여 `paddlepaddle==2.6.2`와의 호환성 확보
2. **zip Lambda 의존성 분리**: ML 의존성(`onnxruntime`, `transformers`, `rapidocr-onnxruntime` 등)을 `requirements-full.txt`로 분리하고, `requirements.txt`는 zip Lambda용으로 경량화 (`requests`, `beautifulsoup4`만 포함)
3. **lazy import 적용**: `app.py`에서 `embedding`, `ocr_client`, `parser.jobkorea`를 `job_detail_crawler` 핸들러 내부에서 import하도록 변경하여 `job_list_collector`가 ML 패키지 없이 동작
4. **Dockerfile 수정**: 컨테이너 이미지 빌드 시 `requirements-full.txt`를 사용하도록 변경
5. **테스트 mock 경로 수정**: lazy import에 맞춰 mock 대상을 원본 모듈 경로로 변경

## #️⃣ 테스트 결과

- `pytest tests/unit/` 55개 테스트 전체 통과

## #️⃣ 변경 사항 체크리스트

- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [x] 문서를 작성하거나 수정했나요? (필요한 경우)
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## 📎 참고 자료 (선택)

- `paddle2onnx 2.1.0`부터 `paddlepaddle >= 3.0.0` 런타임 검증이 추가됨
- Lambda zip 패키지 크기 제한: 압축 해제 시 250MB (262,144,000 bytes)