### PR TITLE
feat: 이미지 JD OCR을 Google Cloud Vision API로 전환

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,4 +49,5 @@ jobs:
             --resolve-image-repos \
             --parameter-overrides \
               S3BucketName=${{ secrets.S3_BUCKET_NAME }} \
-              DiscordWebhookUrl=${{ secrets.DISCORD_WEBHOOK_URL }}
+              DiscordWebhookUrl=${{ secrets.DISCORD_WEBHOOK_URL }} \
+              GcpSaKeyB64=${{ secrets.GCP_SA_KEY_B64 }}

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -22,46 +22,12 @@ t = AutoTokenizer.from_pretrained('snunlp/KR-SBERT-V40K-klueNLI-augSTS'); \
 t.save_pretrained('/tmp/tokenizer/')"
 
 
-# Stage 2: PaddleOCR 한국어 모델 → ONNX 변환
-FROM python:3.11-slim AS ocr-builder
-
-RUN apt-get update && apt-get install -y --no-install-recommends wget libgomp1 \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN pip install --no-cache-dir paddlepaddle==2.6.2 "paddle2onnx>=1.2,<2.0" packaging
-
-# 한국어 PP-OCRv3 rec 모델 다운로드 및 변환
-RUN wget -q https://paddleocr.bj.bcebos.com/PP-OCRv3/multilingual/korean_PP-OCRv3_rec_infer.tar \
-    -O /tmp/korean_rec.tar \
-    && mkdir -p /tmp/paddle_model \
-    && tar -xf /tmp/korean_rec.tar -C /tmp/paddle_model --strip-components=1
-
-RUN mkdir -p /tmp/ocr_models \
-    && paddle2onnx \
-       --model_dir /tmp/paddle_model \
-       --model_filename inference.pdmodel \
-       --params_filename inference.pdiparams \
-       --save_file /tmp/ocr_models/korean_rec.onnx \
-       --opset_version 14
-
-# 한국어 문자 사전 다운로드
-RUN wget -q https://raw.githubusercontent.com/PaddlePaddle/PaddleOCR/release/2.7/ppocr/utils/dict/korean_dict.txt \
-    -O /tmp/ocr_models/korean_dict.txt
-
-
-# Stage 3: Lambda 런타임
+# Stage 2: Lambda 런타임
 FROM public.ecr.aws/lambda/python:3.11
 
 # 임베딩 모델 복사
 COPY --from=embedding-builder /tmp/kr-sbert-uint8.onnx /app/models/kr-sbert-uint8.onnx
 COPY --from=embedding-builder /tmp/tokenizer/ /app/models/tokenizer/
-
-# OCR 모델 복사
-COPY --from=ocr-builder /tmp/ocr_models/korean_rec.onnx /app/ocr_models/korean_rec.onnx
-COPY --from=ocr-builder /tmp/ocr_models/korean_dict.txt /app/ocr_models/korean_dict.txt
-
-# OpenCV 런타임 의존성 (rapidocr-onnxruntime → cv2 → libGL)
-RUN yum install -y mesa-libGL && yum clean all
 
 # 의존성 설치
 COPY src/requirements-full.txt ${LAMBDA_TASK_ROOT}/requirements.txt

--- a/src/ocr_client.py
+++ b/src/ocr_client.py
@@ -61,6 +61,14 @@ def call_ocr(images_b64: list[str]) -> str:
 
     texts: list[str] = []
     for i, annotation in enumerate(resp.json().get("responses", [])):
+        error = annotation.get("error")
+        if error:
+            logger.warning(
+                "OCR 이미지 %d/%d 실패: code=%s %s",
+                i + 1, len(images_b64), error.get("code"), error.get("message"),
+            )
+            continue
+
         full_text = annotation.get("fullTextAnnotation", {}).get("text", "")
         texts.append(full_text)
         logger.info(

--- a/src/ocr_client.py
+++ b/src/ocr_client.py
@@ -1,68 +1,70 @@
-"""로컬 ONNX OCR 모듈. Lambda 에서 PaddleOCR 한국어 모델을 ONNX 로 직접 추론한다."""
+"""Google Cloud Vision OCR 모듈. Lambda 에서 이미지 JD 텍스트를 추출한다."""
 import base64
-import io
+import json
 import logging
 import os
 
+import requests
+
 logger = logging.getLogger(__name__)
 
-_OCR_MODEL_DIR = os.environ.get("OCR_MODEL_DIR", "/app/ocr_models")
-MAX_IMAGE_SIDE = 1500
+VISION_API_URL = "https://vision.googleapis.com/v1/images:annotate"
+_SCOPES = ["https://www.googleapis.com/auth/cloud-vision"]
 
-_ocr_engine = None
-
-
-def _load_ocr():
-    """RapidOCR 엔진을 1회 로딩. Lambda 웜 스타트 시 재사용."""
-    global _ocr_engine
-
-    if _ocr_engine is not None:
-        return
-
-    from rapidocr_onnxruntime import RapidOCR
-
-    rec_model = os.path.join(_OCR_MODEL_DIR, "korean_rec.onnx")
-    rec_dict = os.path.join(_OCR_MODEL_DIR, "korean_dict.txt")
-
-    _ocr_engine = RapidOCR(rec_model_path=rec_model, rec_keys_path=rec_dict)
-    logger.info("ONNX OCR 로드 완료: %s", rec_model)
+_credentials = None
 
 
-def _preprocess_image(img_b64: str):
-    """base64 이미지를 디코딩하고 전처리하여 numpy 배열로 반환."""
-    import numpy as np
-    from PIL import Image
+def _get_credentials():
+    """GCP 서비스 계정 인증 정보를 로드하고 토큰을 갱신한다."""
+    global _credentials
 
-    raw = base64.b64decode(img_b64)
-    pil_img = Image.open(io.BytesIO(raw)).convert("RGB")
+    from google.auth.transport.requests import Request
+    from google.oauth2 import service_account
 
-    w, h = pil_img.size
-    if max(w, h) > MAX_IMAGE_SIDE:
-        scale = MAX_IMAGE_SIDE / max(w, h)
-        pil_img = pil_img.resize((int(w * scale), int(h * scale)), Image.LANCZOS)
+    if _credentials is None:
+        sa_key_b64 = os.environ.get("GCP_SA_KEY_B64", "")
+        sa_info = json.loads(base64.b64decode(sa_key_b64))
+        _credentials = service_account.Credentials.from_service_account_info(
+            sa_info, scopes=_SCOPES,
+        )
+        logger.info("GCP 서비스 계정 로드 완료: %s", sa_info.get("client_email"))
 
-    return np.array(pil_img)
+    if not _credentials.valid:
+        _credentials.refresh(Request())
+
+    return _credentials
 
 
 def call_ocr(images_b64: list[str]) -> str:
-    """이미지 목록을 로컬 ONNX OCR 로 텍스트 추출.
+    """이미지 목록을 Cloud Vision API 로 텍스트 추출.
 
-    각 이미지의 OCR 결과를 줄바꿈으��� 합산하여 반환한다.
+    각 이미지의 OCR 결과를 줄바꿈으로 합산하여 반환한다.
     """
-    _load_ocr()
+    credentials = _get_credentials()
+
+    image_requests = [
+        {
+            "image": {"content": img_b64},
+            "features": [{"type": "TEXT_DETECTION"}],
+            "imageContext": {"languageHints": ["ko"]},
+        }
+        for img_b64 in images_b64
+    ]
+
+    resp = requests.post(
+        VISION_API_URL,
+        json={"requests": image_requests},
+        headers={"Authorization": f"Bearer {credentials.token}"},
+        timeout=30,
+    )
+    resp.raise_for_status()
+
     texts: list[str] = []
+    for i, annotation in enumerate(resp.json().get("responses", [])):
+        full_text = annotation.get("fullTextAnnotation", {}).get("text", "")
+        texts.append(full_text)
+        logger.info(
+            "OCR 이미지 %d/%d 완료: %d자", i + 1, len(images_b64), len(full_text),
+        )
 
-    for i, img_b64 in enumerate(images_b64):
-        img = _preprocess_image(img_b64)
-        result, _ = _ocr_engine(img)
-
-        if result:
-            lines = [item[1] for item in result]
-            text = "\n".join(lines)
-            texts.append(text)
-        else:
-            text = ""
-
-        logger.info("OCR 이미지 %d/%d 완료: %d자", i + 1, len(images_b64), len(text))
-
-    return "\n".join(texts)
+    return "\n".join(t for t in texts if t)

--- a/src/requirements-full.txt
+++ b/src/requirements-full.txt
@@ -3,5 +3,4 @@ beautifulsoup4
 onnxruntime
 transformers
 numpy<2
-rapidocr-onnxruntime
-Pillow
+google-auth

--- a/template.yaml
+++ b/template.yaml
@@ -13,6 +13,11 @@ Parameters:
     Description: DLQ 알람 Discord 웹훅 URL
     NoEcho: true
     Default: ''
+  GcpSaKeyB64:
+    Type: String
+    Description: GCP 서비스 계정 JSON 키 (base64 인코딩)
+    NoEcho: true
+    Default: ''
 
 Globals:
   Function:
@@ -130,6 +135,9 @@ Resources:
       PackageType: Image
       Timeout: 120
       MemorySize: 1536
+      Environment:
+        Variables:
+          GCP_SA_KEY_B64: !Ref GcpSaKeyB64
       Policies:
         - S3CrudPolicy:
             BucketName: !Ref CrawlerDataBucket

--- a/tests/unit/test_ocr_client.py
+++ b/tests/unit/test_ocr_client.py
@@ -1,4 +1,4 @@
-"""ocr_client 단위 테스트. ONNX OCR 엔진은 mock 으로 대체한다."""
+"""ocr_client 단위 테스트. Cloud Vision API 호출은 mock 으로 대체한다."""
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -7,124 +7,116 @@ import ocr_client
 
 
 @pytest.fixture(autouse=True)
-def _reset_ocr_engine():
-    """각 테스트 전에 OCR 엔진 상태를 초기화."""
-    ocr_client._ocr_engine = None
+def _reset_credentials():
+    """각 테스트 전에 인증 정보 상태를 초기화."""
+    ocr_client._credentials = None
     yield
-    ocr_client._ocr_engine = None
+    ocr_client._credentials = None
 
 
-@patch("ocr_client._preprocess_image")
-@patch("ocr_client._load_ocr")
-def test_single_image_returns_text(mock_load, mock_preprocess):
+def _mock_vision_response(*texts):
+    """Cloud Vision API 응답을 모사하는 Response 객체를 생성한다."""
+    responses = []
+    for text in texts:
+        if text:
+            responses.append({"fullTextAnnotation": {"text": text}})
+        else:
+            responses.append({})
+
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = {"responses": responses}
+    mock_resp.raise_for_status = MagicMock()
+    return mock_resp
+
+
+@patch("ocr_client._get_credentials")
+@patch("ocr_client.requests.post")
+def test_single_image_returns_text(mock_post, mock_creds):
     """이미지 1장 전송 시 OCR 결과 텍스트를 반환한다."""
-    mock_preprocess.return_value = "fake_np_array"
-    mock_engine = MagicMock()
-    mock_engine.return_value = (
-        [([0, 0, 100, 30], "주요업무", 0.95), ([0, 30, 100, 60], "백엔드 개발", 0.90)],
-        {"det": 0.1, "rec": 0.2},
-    )
-    ocr_client._ocr_engine = mock_engine
+    mock_creds.return_value = MagicMock(token="fake-token")
+    mock_post.return_value = _mock_vision_response("주요업무\n백엔드 개발")
 
     result = ocr_client.call_ocr(["base64data"])
 
     assert result == "주요업무\n백엔드 개발"
-    mock_engine.assert_called_once_with("fake_np_array")
+    mock_post.assert_called_once()
 
 
-@patch("ocr_client._preprocess_image")
-@patch("ocr_client._load_ocr")
-def test_multiple_images_concatenated(mock_load, mock_preprocess):
+@patch("ocr_client._get_credentials")
+@patch("ocr_client.requests.post")
+def test_multiple_images_concatenated(mock_post, mock_creds):
     """여러 이미지의 OCR 결과가 줄바꿈으로 합산된다."""
-    mock_preprocess.return_value = "fake_np_array"
-    mock_engine = MagicMock()
-    mock_engine.side_effect = [
-        ([([0, 0, 1, 1], "모집분야", 0.9)], {"det": 0.1}),
-        ([([0, 0, 1, 1], "자격요건", 0.9)], {"det": 0.1}),
-    ]
-    ocr_client._ocr_engine = mock_engine
+    mock_creds.return_value = MagicMock(token="fake-token")
+    mock_post.return_value = _mock_vision_response("모집분야", "자격요건")
 
     result = ocr_client.call_ocr(["img1", "img2"])
 
     assert result == "모집분야\n자격요건"
-    assert mock_engine.call_count == 2
 
 
-@patch("ocr_client._preprocess_image")
-@patch("ocr_client._load_ocr")
-def test_empty_ocr_result_skipped(mock_load, mock_preprocess):
-    """OCR 결과가 없으면(None) 합산에서 제외된다."""
-    mock_preprocess.return_value = "fake_np_array"
-    mock_engine = MagicMock()
-    mock_engine.side_effect = [
-        (None, {"det": 0.1}),
-        ([([0, 0, 1, 1], "자격요건", 0.9)], {"det": 0.1}),
-    ]
-    ocr_client._ocr_engine = mock_engine
+@patch("ocr_client._get_credentials")
+@patch("ocr_client.requests.post")
+def test_empty_ocr_result_skipped(mock_post, mock_creds):
+    """OCR 결과가 없으면 합산에서 제외된다."""
+    mock_creds.return_value = MagicMock(token="fake-token")
+    mock_post.return_value = _mock_vision_response("", "자격요건")
 
     result = ocr_client.call_ocr(["img1", "img2"])
 
     assert result == "자격요건"
 
 
-@patch("ocr_client._preprocess_image")
-@patch("ocr_client._load_ocr")
-def test_all_empty_returns_empty_string(mock_load, mock_preprocess):
+@patch("ocr_client._get_credentials")
+@patch("ocr_client.requests.post")
+def test_all_empty_returns_empty_string(mock_post, mock_creds):
     """모든 OCR 결과가 비면 빈 문자열을 반환한다."""
-    mock_preprocess.return_value = "fake_np_array"
-    mock_engine = MagicMock()
-    mock_engine.return_value = (None, {"det": 0.1})
-    ocr_client._ocr_engine = mock_engine
+    mock_creds.return_value = MagicMock(token="fake-token")
+    mock_post.return_value = _mock_vision_response("")
 
     result = ocr_client.call_ocr(["img1"])
 
     assert result == ""
 
 
-@patch("ocr_client._load_ocr")
-def test_preprocess_resizes_large_image(mock_load):
-    """1500px 초과 이미지가 비율 유지하며 리사이즈된다."""
-    import base64
-    from PIL import Image
-    import io
-
-    img = Image.new("RGB", (3000, 2000), color=(255, 0, 0))
-    buf = io.BytesIO()
-    img.save(buf, format="PNG")
-    img_b64 = base64.b64encode(buf.getvalue()).decode("ascii")
-
-    result = ocr_client._preprocess_image(img_b64)
-
-    assert max(result.shape[0], result.shape[1]) <= 1500
-
-
-@patch("ocr_client._load_ocr")
-def test_preprocess_keeps_small_image(mock_load):
-    """1500px 이하 이미지는 리사이즈하지 않는다."""
-    import base64
-    from PIL import Image
-    import io
-
-    img = Image.new("RGB", (800, 600), color=(0, 255, 0))
-    buf = io.BytesIO()
-    img.save(buf, format="PNG")
-    img_b64 = base64.b64encode(buf.getvalue()).decode("ascii")
-
-    result = ocr_client._preprocess_image(img_b64)
-
-    assert result.shape[1] == 800
-    assert result.shape[0] == 600
-
-
-@patch("ocr_client._preprocess_image")
-@patch("ocr_client._load_ocr")
-def test_lazy_loading_called(mock_load, mock_preprocess):
-    """call_ocr 호출 시 _load_ocr 가 한 번 호출된다."""
-    mock_preprocess.return_value = "fake_np_array"
-    mock_engine = MagicMock()
-    mock_engine.return_value = (None, {})
-    ocr_client._ocr_engine = mock_engine
+@patch("ocr_client._get_credentials")
+@patch("ocr_client.requests.post")
+def test_request_includes_language_hint(mock_post, mock_creds):
+    """요청에 한국어 languageHints 가 포함된다."""
+    mock_creds.return_value = MagicMock(token="fake-token")
+    mock_post.return_value = _mock_vision_response("텍스트")
 
     ocr_client.call_ocr(["img1"])
 
-    mock_load.assert_called_once()
+    call_kwargs = mock_post.call_args
+    body = call_kwargs.kwargs.get("json") or call_kwargs[1].get("json")
+    image_req = body["requests"][0]
+    assert image_req["imageContext"]["languageHints"] == ["ko"]
+
+
+@patch("ocr_client._get_credentials")
+@patch("ocr_client.requests.post")
+def test_request_uses_bearer_token(mock_post, mock_creds):
+    """요청 헤더에 Bearer 토큰이 포함된다."""
+    mock_creds.return_value = MagicMock(token="test-token-123")
+    mock_post.return_value = _mock_vision_response("텍스트")
+
+    ocr_client.call_ocr(["img1"])
+
+    call_kwargs = mock_post.call_args
+    headers = call_kwargs.kwargs.get("headers") or call_kwargs[1].get("headers")
+    assert headers["Authorization"] == "Bearer test-token-123"
+
+
+@patch("ocr_client._get_credentials")
+@patch("ocr_client.requests.post")
+def test_batch_request_sends_all_images(mock_post, mock_creds):
+    """여러 이미지를 한 번의 API 호출로 배치 전송한다."""
+    mock_creds.return_value = MagicMock(token="fake-token")
+    mock_post.return_value = _mock_vision_response("a", "b", "c")
+
+    ocr_client.call_ocr(["img1", "img2", "img3"])
+
+    call_kwargs = mock_post.call_args
+    body = call_kwargs.kwargs.get("json") or call_kwargs[1].get("json")
+    assert len(body["requests"]) == 3
+    mock_post.assert_called_once()

--- a/tests/unit/test_ocr_client.py
+++ b/tests/unit/test_ocr_client.py
@@ -120,3 +120,23 @@ def test_batch_request_sends_all_images(mock_post, mock_creds):
     body = call_kwargs.kwargs.get("json") or call_kwargs[1].get("json")
     assert len(body["requests"]) == 3
     mock_post.assert_called_once()
+
+
+@patch("ocr_client._get_credentials")
+@patch("ocr_client.requests.post")
+def test_image_error_logged_and_skipped(mock_post, mock_creds):
+    """개별 이미지 에러가 로깅되고 결과에서 제외된다."""
+    mock_creds.return_value = MagicMock(token="fake-token")
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = {
+        "responses": [
+            {"error": {"code": 3, "message": "Bad image data"}},
+            {"fullTextAnnotation": {"text": "정상 텍스트"}},
+        ],
+    }
+    mock_resp.raise_for_status = MagicMock()
+    mock_post.return_value = mock_resp
+
+    result = ocr_client.call_ocr(["bad_img", "good_img"])
+
+    assert result == "정상 텍스트"


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#39

## #️⃣ 작업 내용

이미지 JD의 OCR 처리를 기존 로컬 ONNX PaddleOCR에서 Google Cloud Vision API(`TEXT_DETECTION`)로 전환한다.

### 전환 배경

이전 테스트(#33 후속)에서 PaddleOCR ONNX 기반 OCR에 세 가지 문제가 확인되었다:

**1. OCR 품질 부적합**

PaddleOCR 한국어 모델(PP-OCRv3)이 디자인 포스터형 채용공고 이미지에서 심각한 인식 오류를 보였다.

| 공고 | OCR 결과 |
|------|---------|
| 신한은행 (표 형태) | 한글 인식은 되지만 오탈자 다수 ("시뮬레이션" -> "시물레이션") |
| GS리테일 (컬러 배경) | 일부 문장 읽기 가능하나 노이즈 섞임 |
| 기아 (디자인 포스터) | `+++`, `h++` 같은 의미없는 문자 대량 발생 |

잘못된 OCR 텍스트로 임베딩을 계산하면 매칭 품질이 오히려 하락한다.

**2. Lambda 메모리 초과 (OOM)**

이미지 4장짜리 공고에서 `Runtime.OutOfMemory` 발생 (1536MB, 3건). OCR 엔진(`_ocr_engine`)과 임베딩 모델(`_ort_session`)이 모두 전역 변수로 캐싱되어 동시에 메모리에 상주하기 때문이다.

**3. 컨테이너 이미지 비대화**

PaddleOCR ONNX를 위한 Dockerfile 구성:
- Stage 2 (ocr-builder): paddlepaddle + paddle2onnx 모델 변환 빌드 스테이지
- 런타임 의존성: `rapidocr-onnxruntime`, `opencv-python`, `Pillow`, `mesa-libGL`
- 모델 파일: `korean_rec.onnx`, `korean_dict.txt`

### 대안 비교 및 선택

| 방안 | 비용 (1,000장) | 한국어 지원 | Lambda 메모리 |
|------|---------------|-----------|-------------|
| PaddleOCR ONNX (현재) | $0 | O (품질 낮음) | OOM 발생 |
| AWS Textract | $1.50 | **X (미지원)** | 없음 |
| **Google Cloud Vision** | **$1.50** | **O** | **없음** |
| Naver Clova OCR | 3원/건 (약 $2) | O | 없음 |
| GPT-4o Vision | $0.01-$0.03/장 | O | 없음 |

Google Cloud Vision 선택 이유:
- 한국어 공식 지원 (AWS Textract는 한국어 미지원)
- 월 첫 1,000장 영구 무료 (Textract는 신규 3개월만)
- `requests`(기존 의존성) + `google-auth`(경량)만으로 구현 가능
- API 호출만 하므로 OOM 완전 해소

### 변경 상세

**커밋 1: `79ae07d` - OCR 전환 핵심 코드**

| 파일 | 변경 내용 |
|------|----------|
| `src/ocr_client.py` | PaddleOCR ONNX 로컬 추론을 Cloud Vision REST API 호출로 전면 재작성. `google-auth`로 서비스 계정 토큰 발급, 여러 이미지를 1회 API 호출로 배치 전송, 한국어 `languageHints` 지정. 기존 `call_ocr(images_b64) -> str` 인터페이스 유지. |
| `src/requirements-full.txt` | `rapidocr-onnxruntime`, `Pillow` 제거. `google-auth` 추가. |
| `tests/unit/test_ocr_client.py` | Cloud Vision API mock 기반 테스트 7개로 재작성 (단일/다중 이미지, 빈 결과, languageHints, Bearer 토큰, 배치 전송 검증). |

**커밋 2: `081aa66` - Dockerfile 경량화**

| 파일 | 변경 내용 |
|------|----------|
| `src/Dockerfile` | Stage 2 (ocr-builder: paddlepaddle + paddle2onnx) 전체 제거. OCR 모델 COPY 제거 (`korean_rec.onnx`, `korean_dict.txt`). `mesa-libGL` 시스템 패키지 제거. 3-stage -> 2-stage 빌드로 간소화. |

**커밋 3: `2988b76` - 인프라/배포 설정**

| 파일 | 변경 내용 |
|------|----------|
| `template.yaml` | `GcpSaKeyB64` 파라미터(NoEcho) 추가. `JobDetailCrawler` Lambda에 `GCP_SA_KEY_B64` 환경변수 추가. |
| `.github/workflows/deploy.yml` | SAM deploy `--parameter-overrides`에 `GcpSaKeyB64=${{ secrets.GCP_SA_KEY_B64 }}` 전달 추가. |

**커밋 4: `8fea225` - 배치 응답 에러 처리**

| 파일 | 변경 내용 |
|------|----------|
| `src/ocr_client.py` | Cloud Vision 배치 응답의 개별 이미지 `error` 필드를 확인하여 warning 로그(code, message)를 남기고 해당 이미지를 결과에서 제외. |
| `tests/unit/test_ocr_client.py` | 에러 이미지가 로깅되고 정상 이미지만 반환되는 테스트 추가. |

### 제거된 의존성 요약

| 제거 항목 | 이유 |
|----------|------|
| `rapidocr-onnxruntime` | 로컬 OCR 엔진 -> Cloud Vision API로 대체 |
| `Pillow` | OCR 이미지 전처리용 -> Cloud Vision이 원본 base64 직접 처리 |
| `mesa-libGL` (시스템 패키지) | opencv-python의 libGL 의존성 -> opencv 자체가 불필요 |
| Dockerfile Stage 2 (ocr-builder) | paddlepaddle + paddle2onnx 모델 변환 -> 모델 파일 불필요 |
| `korean_rec.onnx`, `korean_dict.txt` | PaddleOCR 한국어 모델 파일 -> Cloud Vision API가 처리 |

### 추가된 의존성

| 추가 항목 | 용도 |
|----------|------|
| `google-auth` (pip) | GCP 서비스 계정 JWT 토큰 발급 |
| `GCP_SA_KEY_B64` (환경변수) | 서비스 계정 JSON 키 (base64 인코딩, GitHub Secrets에 등록 완료) |

## #️⃣ 테스트 결과

단위 테스트 56개 전체 통과 (Cloud Vision API mock 기반 8개 테스트 포함)

```
tests/unit/test_ocr_client.py::test_single_image_returns_text PASSED
tests/unit/test_ocr_client.py::test_multiple_images_concatenated PASSED
tests/unit/test_ocr_client.py::test_empty_ocr_result_skipped PASSED
tests/unit/test_ocr_client.py::test_all_empty_returns_empty_string PASSED
tests/unit/test_ocr_client.py::test_request_includes_language_hint PASSED
tests/unit/test_ocr_client.py::test_request_uses_bearer_token PASSED
tests/unit/test_ocr_client.py::test_batch_request_sends_all_images PASSED
tests/unit/test_ocr_client.py::test_image_error_logged_and_skipped PASSED
======================== 56 passed in 0.62s =========================
```

## #️⃣ 변경 사항 체크리스트

- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [x] 문서를 작성하거나 수정했나요? (필요한 경우)
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## #️⃣ 리뷰 요구사항 (선택)

- `src/ocr_client.py`의 Cloud Vision API 호출 흐름 및 GCP 서비스 계정 인증 로직 확인
- `template.yaml`의 `GcpSaKeyB64` 파라미터가 `NoEcho: true`로 설정되어 비밀 정보가 CloudFormation 콘솔에 노출되지 않는지 확인
- Dockerfile에서 OCR 관련 스테이지/의존성이 완전히 제거되었는지 확인

## 📎 참고 자료 (선택)

- [Google Cloud Vision API TEXT_DETECTION 문서](https://cloud.google.com/vision/docs/ocr)
- [Google Cloud Vision 가격](https://cloud.google.com/vision/pricing): TEXT_DETECTION $1.50/1,000장, 월 첫 1,000장 영구 무료
- [AWS Textract FAQ - 지원 언어](https://aws.amazon.com/textract/faqs/): 한국어 미지원
