### PR TITLE
feat: 네이버 뉴스 검색 API 연동 모듈 및 Lambda 핸들러 추가

### DIFF
--- a/scripts/news_smoke.py
+++ b/scripts/news_smoke.py
@@ -1,0 +1,58 @@
+"""네이버 뉴스 수집 로컬 스모크 테스트.
+
+사용법:
+    .venv/bin/python scripts/news_smoke.py                    # 카카오 1개 기업
+    .venv/bin/python scripts/news_smoke.py 네이버 삼성전자    # 지정 기업
+"""
+import logging
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from collector.naver_news import NaverNewsCollector, news_item_to_detail_dict
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+
+
+def main():
+    companies = tuple(sys.argv[1:]) if len(sys.argv) > 1 else ("카카오",)
+
+    import os
+    client_id = os.environ.get("NAVER_CLIENT_ID", "")
+    client_secret = os.environ.get("NAVER_CLIENT_SECRET", "")
+    if not client_id or not client_secret:
+        print("환경변수 NAVER_CLIENT_ID, NAVER_CLIENT_SECRET 를 설정해주세요.")
+        print("  export NAVER_CLIENT_ID=xxx")
+        print("  export NAVER_CLIENT_SECRET=xxx")
+        sys.exit(1)
+
+    collector = NaverNewsCollector(
+        client_id=client_id,
+        client_secret=client_secret,
+        companies=companies,
+        api_delay=0.2,
+    )
+
+    items = collector.collect_all()
+
+    print(f"\n{'='*60}")
+    print(f"수집 결과: {len(items)}건 (기업: {', '.join(companies)})")
+    print(f"{'='*60}\n")
+
+    for i, item in enumerate(items[:10], 1):
+        d = news_item_to_detail_dict(item)
+        print(f"[{i}] {item.title}")
+        print(f"    기업: {item.company_name}")
+        print(f"    URL: {item.url}")
+        print(f"    발행: {item.pub_date.strftime('%Y-%m-%d %H:%M')}")
+        print(f"    ID: {d['external_id']}")
+        print(f"    설명: {item.description[:80]}...")
+        print()
+
+    if len(items) > 10:
+        print(f"... 외 {len(items) - 10}건 생략")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/app.py
+++ b/src/app.py
@@ -1,6 +1,7 @@
 """passroute-crawler Lambda 핸들러.
 
 EventBridge cron → [job_list_collector] → SQS → [job_detail_crawler] → S3 → EC2 consumer → ChromaDB
+EventBridge cron → [news_collector] → S3 → EC2 consumer → ChromaDB
 """
 import json
 import logging
@@ -9,6 +10,7 @@ from datetime import datetime, timedelta, timezone
 
 import boto3
 
+from collector.naver_news import NaverNewsCollector, news_item_to_detail_dict
 from crawler.base import ImageJobDetail, JobDetail, JobListingRef
 from crawler.registry import get_crawler, iter_sources
 from storage.s3 import S3Storage
@@ -135,6 +137,53 @@ def job_detail_crawler(event, context):
             raise
 
     return {"statusCode": 200}
+
+
+# ── Lambda 3: 뉴스 수집 (cron) ──
+
+
+def news_collector(event, context):
+    """주요 기업의 기술/사업 동향 뉴스를 수집하여 S3 에 저장."""
+    from embedding import build_document, embed_text  # noqa: C0415
+
+    client_id = _required_env("NAVER_CLIENT_ID")
+    client_secret = _required_env("NAVER_CLIENT_SECRET")
+    storage = _make_storage()
+
+    existing_urls = storage.get_all_urls()
+
+    collector = NaverNewsCollector(client_id=client_id, client_secret=client_secret)
+    items = collector.collect_all()
+
+    saved = 0
+    skipped = 0
+    for item in items:
+        if item.url in existing_urls:
+            skipped += 1
+            continue
+
+        data = news_item_to_detail_dict(item)
+
+        try:
+            document = build_document(data["raw_text"], tuple(data["tech_stack"]))
+            embedding = embed_text(document)
+            data["embedding"] = embedding
+        except Exception:
+            logger.exception("임베딩 실패, 임베딩 없이 저장: id=%s", data["external_id"])
+
+        key = f"parsed/{data['source']}/{data['external_id']}.json"
+        storage.s3.put_object(
+            Bucket=storage.bucket,
+            Key=key,
+            Body=json.dumps(data, ensure_ascii=False).encode("utf-8"),
+        )
+        saved += 1
+
+    logger.info("뉴스 수집 완료: 저장 %d건, 중복 스킵 %d건", saved, skipped)
+    return {
+        "statusCode": 200,
+        "body": json.dumps({"saved": saved, "skipped": skipped}),
+    }
 
 
 def _process_image_jd(image_detail: ImageJobDetail) -> JobDetail | None:

--- a/src/collector/naver_news.py
+++ b/src/collector/naver_news.py
@@ -1,0 +1,239 @@
+"""네이버 뉴스 검색 API 연동 모듈.
+
+주요 기업의 기술/사업 동향 뉴스를 수집하여 면접 질문 생성에 활용한다.
+"""
+import hashlib
+import html
+import logging
+import os
+import re
+import time
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from email.utils import parsedate_to_datetime
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+KST = timezone(timedelta(hours=9))
+
+NAVER_NEWS_API_URL = "https://openapi.naver.com/v1/search/news.json"
+MAX_DISPLAY = 100
+NEWS_RETENTION_DAYS = 90
+
+# ── 검색 대상 기업 목록 ──
+
+_DEFAULT_COMPANIES: tuple[str, ...] = (
+    # 네이버 계열
+    "네이버", "네이버웹툰", "네이버클라우드", "네이버파이낸셜", "네이버랩스", "네이버제트",
+    # 카카오 계열
+    "카카오", "카카오뱅크", "카카오페이", "카카오모빌리티",
+    "카카오엔터테인먼트", "카카오엔터프라이즈", "카카오스타일", "카카오게임즈",
+    # 토스 계열
+    "토스", "토스뱅크", "토스증권", "토스페이먼츠",
+    # 삼성
+    "삼성전자", "삼성SDS", "삼성카드",
+    # LG
+    "LG CNS", "LG전자",
+    # SK
+    "SK", "SK C&C", "SK플래닛", "SK텔레콤",
+    # KT / 현대 / 한화 / 롯데 / CJ / 신세계
+    "KT", "현대오토에버", "현대카드", "한화시스템",
+    "롯데정보통신", "롯데ON", "CJ올리브네트웍스", "SSG.COM",
+    # 금융권 — 시중은행
+    "KB국민은행", "신한은행", "하나은행", "우리은행", "우리FIS", "iM뱅크",
+    # 금융권 — 인터넷전문은행 (카카오뱅크·토스뱅크 위에서 포함)
+    "케이뱅크",
+    # 금융권 — 지방은행
+    "부산은행", "경남은행", "전북은행", "광주은행", "제주은행",
+    # 금융권 — 특수/국책은행
+    "NH농협은행", "Sh수협은행", "KDB산업은행", "IBK기업은행",
+    # 금융권 — 카드/증권
+    "신한카드", "현대카드", "하나카드",
+    "미래에셋증권", "한국투자증권", "NH투자증권", "삼성증권", "KB증권",
+    # 주요 IT 기업
+    "라인", "쿠팡", "우아한형제들", "당근",
+)
+
+# 검색어 접미사: 기업명 + 접미사 조합으로 검색
+_SEARCH_SUFFIXES: tuple[str, ...] = ("기술", "AI", "개발")
+
+# ── 노이즈 필터링 ──
+
+_EXCLUDE_TITLE_KEYWORDS: tuple[str, ...] = (
+    "주가", "주식", "주주", "배당", "시세", "종가", "상한가", "하한가",
+    "인사", "승진", "부고", "소송", "재판", "기소", "구속",
+    "부동산", "아파트", "분양",
+    "선거", "후보", "의원", "국회", "정당",
+)
+
+# ── API 호출 간격 (초) ──
+
+_DEFAULT_API_DELAY = 0.1
+
+
+@dataclass(frozen=True)
+class NewsItem:
+    """뉴스 검색 결과 1건."""
+    company_name: str
+    title: str
+    description: str
+    url: str
+    pub_date: datetime
+    collected_at: str
+
+
+def _strip_html(text: str) -> str:
+    """HTML 태그와 엔티티를 제거한다."""
+    cleaned = re.sub(r"<[^>]+>", "", text)
+    return html.unescape(cleaned).strip()
+
+
+def _parse_pub_date(date_str: str) -> datetime:
+    """RFC 2822 형식의 pubDate 를 datetime 으로 변환."""
+    try:
+        return parsedate_to_datetime(date_str)
+    except (ValueError, TypeError):
+        return datetime.now(KST)
+
+
+def _make_external_id(url: str) -> str:
+    """URL 에서 결정적 external_id 를 생성."""
+    return hashlib.md5(url.encode()).hexdigest()[:12]
+
+
+def _is_noise(title: str) -> bool:
+    """제목 기반 노이즈 판별."""
+    for kw in _EXCLUDE_TITLE_KEYWORDS:
+        if kw in title:
+            return True
+    return False
+
+
+def _is_relevant(company: str, title: str) -> bool:
+    """기업명이 제목에 포함되어야 관련 기사로 판정.
+
+    설명(description)에만 언급되는 경우 '카카오톡 대화' 같은
+    우연한 언급이 대부분이므로 제목 기준으로 필터링한다.
+    """
+    return company in title
+
+
+def _deadline_from_pub_date(pub_date: datetime) -> int:
+    """pub_date + 90일을 Unix timestamp 로 변환. 기존 deadline 삭제 로직과 호환."""
+    expiry = pub_date + timedelta(days=NEWS_RETENTION_DAYS)
+    return int(expiry.timestamp())
+
+
+class NaverNewsCollector:
+    """네이버 뉴스 검색 API 를 사용해 기업별 기술/사업 동향 뉴스를 수집한다."""
+
+    def __init__(
+        self,
+        client_id: str | None = None,
+        client_secret: str | None = None,
+        *,
+        companies: tuple[str, ...] | None = None,
+        search_suffixes: tuple[str, ...] | None = None,
+        api_delay: float = _DEFAULT_API_DELAY,
+    ):
+        self.client_id = client_id or os.environ.get("NAVER_CLIENT_ID", "")
+        self.client_secret = client_secret or os.environ.get("NAVER_CLIENT_SECRET", "")
+        self.companies = companies or _DEFAULT_COMPANIES
+        self.search_suffixes = search_suffixes or _SEARCH_SUFFIXES
+        self.api_delay = api_delay
+
+    def _call_api(self, query: str, display: int = MAX_DISPLAY, start: int = 1) -> dict:
+        """네이버 뉴스 검색 API 호출."""
+        headers = {
+            "X-Naver-Client-Id": self.client_id,
+            "X-Naver-Client-Secret": self.client_secret,
+        }
+        params = {
+            "query": query,
+            "display": display,
+            "start": start,
+            "sort": "date",
+        }
+        resp = requests.get(
+            NAVER_NEWS_API_URL, headers=headers, params=params, timeout=10,
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    def _search_company(self, company: str) -> list[NewsItem]:
+        """한 기업에 대해 검색어 접미사별로 뉴스를 수집한다."""
+        seen_urls: set[str] = set()
+        items: list[NewsItem] = []
+        now_iso = datetime.now(KST).isoformat()
+
+        for suffix in self.search_suffixes:
+            query = f"{company} {suffix}"
+            try:
+                data = self._call_api(query)
+            except Exception:
+                logger.exception("API 호출 실패: query=%s", query)
+                continue
+
+            for raw in data.get("items", []):
+                url = raw.get("originallink") or raw.get("link", "")
+                if not url or url in seen_urls:
+                    continue
+                seen_urls.add(url)
+
+                title = _strip_html(raw.get("title", ""))
+                description = _strip_html(raw.get("description", ""))
+
+                if _is_noise(title):
+                    continue
+                if not _is_relevant(company, title):
+                    continue
+
+                items.append(NewsItem(
+                    company_name=company,
+                    title=title,
+                    description=description,
+                    url=url,
+                    pub_date=_parse_pub_date(raw.get("pubDate", "")),
+                    collected_at=now_iso,
+                ))
+
+            time.sleep(self.api_delay)
+
+        return items
+
+    def collect_all(self) -> list[NewsItem]:
+        """전체 기업에 대해 뉴스를 수집한다. URL 기준 전역 중복 제거."""
+        all_items: list[NewsItem] = []
+        global_seen_urls: set[str] = set()
+
+        for company in self.companies:
+            items = self._search_company(company)
+            for item in items:
+                if item.url in global_seen_urls:
+                    continue
+                global_seen_urls.add(item.url)
+                all_items.append(item)
+
+            logger.info("company=%s: %d건 수집", company, len(items))
+
+        logger.info("전체 뉴스 수집 완료: %d건 (기업 %d개)", len(all_items), len(self.companies))
+        return all_items
+
+
+def news_item_to_detail_dict(item: NewsItem) -> dict:
+    """NewsItem 을 S3 저장용 dict 로 변환. JobDetail 호환 형식."""
+    raw_text = f"{item.title}\n\n{item.description}"
+    return {
+        "source": "naver_news",
+        "external_id": _make_external_id(item.url),
+        "url": item.url,
+        "company_name": item.company_name,
+        "title": item.title,
+        "raw_text": raw_text,
+        "tech_stack": [],
+        "deadline": _deadline_from_pub_date(item.pub_date),
+        "crawled_at": item.collected_at,
+        "career_level": "",
+    }

--- a/tests/unit/test_naver_news.py
+++ b/tests/unit/test_naver_news.py
@@ -1,0 +1,327 @@
+"""네이버 뉴스 수집 모듈 단위 테스트.
+
+API 호출은 mock 으로 대체하고, 노이즈 필터링·HTML 태그 제거·
+pubDate 파싱·중복 제거·deadline 계산 등을 검증한다.
+"""
+import json
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from collector.naver_news import (
+    NaverNewsCollector,
+    NewsItem,
+    _deadline_from_pub_date,
+    _is_noise,
+    _is_relevant,
+    _make_external_id,
+    _parse_pub_date,
+    _strip_html,
+    news_item_to_detail_dict,
+)
+
+KST = timezone(timedelta(hours=9))
+
+
+# ── _strip_html ──
+
+
+class TestStripHtml:
+    def test_removes_bold_tags(self):
+        assert _strip_html("<b>카카오</b> AI 신사업") == "카카오 AI 신사업"
+
+    def test_unescapes_html_entities(self):
+        assert _strip_html("A&amp;B &quot;test&quot;") == 'A&B "test"'
+
+    def test_empty_string(self):
+        assert _strip_html("") == ""
+
+    def test_no_tags(self):
+        assert _strip_html("순수 텍스트") == "순수 텍스트"
+
+
+# ── _parse_pub_date ──
+
+
+class TestParsePubDate:
+    def test_rfc2822_format(self):
+        dt = _parse_pub_date("Mon, 26 Sep 2016 07:50:00 +0900")
+        assert dt.year == 2016
+        assert dt.month == 9
+        assert dt.day == 26
+
+    def test_invalid_format_returns_now(self):
+        dt = _parse_pub_date("invalid-date")
+        assert dt.tzinfo is not None
+
+
+# ── _make_external_id ──
+
+
+class TestMakeExternalId:
+    def test_deterministic(self):
+        url = "https://example.com/article/123"
+        assert _make_external_id(url) == _make_external_id(url)
+
+    def test_different_urls_differ(self):
+        assert _make_external_id("https://a.com") != _make_external_id("https://b.com")
+
+    def test_length(self):
+        assert len(_make_external_id("https://example.com")) == 12
+
+
+# ── _is_noise ──
+
+
+class TestIsNoise:
+    @pytest.mark.parametrize("title", [
+        "삼성전자 주가 급등",
+        "카카오 인사 발령",
+        "네이버 소송 결과",
+        "토스 주주총회",
+    ])
+    def test_noise_detected(self, title):
+        assert _is_noise(title) is True
+
+    @pytest.mark.parametrize("title", [
+        "카카오 AI 기반 추천 시스템 전면 개편",
+        "네이버 클라우드 신규 서비스 출시",
+        "토스 개발팀 기술 블로그 공개",
+    ])
+    def test_non_noise(self, title):
+        assert _is_noise(title) is False
+
+
+# ── _is_relevant ──
+
+
+class TestIsRelevant:
+    def test_company_in_title(self):
+        assert _is_relevant("카카오", "카카오 AI 신사업 발표") is True
+
+    def test_company_not_in_title(self):
+        assert _is_relevant("카카오", "AI 신사업 발표") is False
+
+    def test_company_substring_match(self):
+        assert _is_relevant("카카오", "카카오뱅크 투자탭 출시") is True
+
+
+# ── _deadline_from_pub_date ──
+
+
+class TestDeadlineFromPubDate:
+    def test_adds_90_days(self):
+        pub_date = datetime(2026, 1, 1, 0, 0, 0, tzinfo=KST)
+        expected = datetime(2026, 4, 1, 0, 0, 0, tzinfo=KST)
+        assert _deadline_from_pub_date(pub_date) == int(expected.timestamp())
+
+
+# ── news_item_to_detail_dict ──
+
+
+class TestNewsItemToDetailDict:
+    def test_fields(self):
+        item = NewsItem(
+            company_name="카카오",
+            title="카카오 AI 신사업",
+            description="카카오가 AI 기반 신사업을 발표했다.",
+            url="https://example.com/news/1",
+            pub_date=datetime(2026, 4, 1, 12, 0, 0, tzinfo=KST),
+            collected_at="2026-04-01T12:00:00+09:00",
+        )
+        d = news_item_to_detail_dict(item)
+
+        assert d["source"] == "naver_news"
+        assert d["company_name"] == "카카오"
+        assert d["title"] == "카카오 AI 신사업"
+        assert "카카오 AI 신사업" in d["raw_text"]
+        assert "카카오가 AI 기반 신사업을 발표했다." in d["raw_text"]
+        assert d["tech_stack"] == []
+        assert d["career_level"] == ""
+        assert isinstance(d["deadline"], int)
+        assert d["external_id"] == _make_external_id(item.url)
+
+
+# ── NaverNewsCollector ──
+
+
+def _make_api_response(items: list[dict]) -> dict:
+    return {"items": items}
+
+
+def _make_raw_item(title: str, url: str, desc: str = "설명", pub_date: str = "Mon, 01 Apr 2026 12:00:00 +0900") -> dict:
+    return {
+        "title": title,
+        "originallink": url,
+        "link": f"https://n.news.naver.com/{url}",
+        "description": desc,
+        "pubDate": pub_date,
+    }
+
+
+class TestNaverNewsCollector:
+    def _make_collector(self, **kwargs):
+        defaults = dict(
+            client_id="test_id",
+            client_secret="test_secret",
+            companies=("카카오",),
+            search_suffixes=("기술",),
+            api_delay=0,
+        )
+        defaults.update(kwargs)
+        return NaverNewsCollector(**defaults)
+
+    @patch("collector.naver_news.requests.get")
+    def test_collect_all_basic(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = _make_api_response([
+            _make_raw_item("<b>카카오</b> AI 신기술", "https://news.com/1"),
+            _make_raw_item("카카오 클라우드 확장", "https://news.com/2"),
+        ])
+        mock_resp.raise_for_status = MagicMock()
+        mock_get.return_value = mock_resp
+
+        collector = self._make_collector()
+        items = collector.collect_all()
+
+        assert len(items) == 2
+        assert items[0].title == "카카오 AI 신기술"  # HTML 태그 제거됨
+        assert items[0].company_name == "카카오"
+
+    @patch("collector.naver_news.requests.get")
+    def test_noise_filtered(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = _make_api_response([
+            _make_raw_item("카카오 주가 급등", "https://news.com/1"),
+            _make_raw_item("카카오 AI 출시", "https://news.com/2"),
+        ])
+        mock_resp.raise_for_status = MagicMock()
+        mock_get.return_value = mock_resp
+
+        collector = self._make_collector()
+        items = collector.collect_all()
+
+        assert len(items) == 1
+        assert items[0].title == "카카오 AI 출시"
+
+    @patch("collector.naver_news.requests.get")
+    def test_url_deduplication_across_suffixes(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = _make_api_response([
+            _make_raw_item("카카오 AI 기술", "https://news.com/same"),
+        ])
+        mock_resp.raise_for_status = MagicMock()
+        mock_get.return_value = mock_resp
+
+        collector = self._make_collector(search_suffixes=("기술", "AI"))
+        items = collector.collect_all()
+
+        assert len(items) == 1
+
+    @patch("collector.naver_news.requests.get")
+    def test_url_deduplication_across_companies(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = _make_api_response([
+            _make_raw_item("카카오 네이버 공통 뉴스", "https://news.com/shared"),
+        ])
+        mock_resp.raise_for_status = MagicMock()
+        mock_get.return_value = mock_resp
+
+        collector = self._make_collector(companies=("카카오", "네이버"))
+        items = collector.collect_all()
+
+        assert len(items) == 1
+
+    @patch("collector.naver_news.requests.get")
+    def test_api_error_continues(self, mock_get):
+        """API 호출 실패 시 해당 기업은 건너뛰고 계속 진행."""
+        mock_get.side_effect = Exception("API error")
+
+        collector = self._make_collector()
+        items = collector.collect_all()
+
+        assert items == []
+
+    @patch("collector.naver_news.requests.get")
+    def test_api_headers(self, mock_get):
+        """API 호출 시 인증 헤더가 포함되는지 검증."""
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = _make_api_response([])
+        mock_resp.raise_for_status = MagicMock()
+        mock_get.return_value = mock_resp
+
+        collector = self._make_collector()
+        collector.collect_all()
+
+        call_kwargs = mock_get.call_args
+        headers = call_kwargs.kwargs["headers"]
+        assert headers["X-Naver-Client-Id"] == "test_id"
+        assert headers["X-Naver-Client-Secret"] == "test_secret"
+
+
+# ── news_collector 핸들러 ──
+
+
+class TestNewsCollectorHandler:
+    @patch("app.NaverNewsCollector")
+    @patch("app._make_storage")
+    def test_handler_saves_new_news(self, mock_storage_fn, mock_collector_cls, monkeypatch):
+        monkeypatch.setenv("NAVER_CLIENT_ID", "test_id")
+        monkeypatch.setenv("NAVER_CLIENT_SECRET", "test_secret")
+
+        mock_storage = MagicMock()
+        mock_storage.get_all_urls.return_value = set()
+        mock_storage.bucket = "test-bucket"
+        mock_storage_fn.return_value = mock_storage
+
+        item = NewsItem(
+            company_name="카카오",
+            title="카카오 AI",
+            description="설명",
+            url="https://news.com/new",
+            pub_date=datetime(2026, 4, 1, tzinfo=KST),
+            collected_at="2026-04-01T12:00:00+09:00",
+        )
+        mock_collector_cls.return_value.collect_all.return_value = [item]
+
+        import app as app_module
+        with patch.object(app_module, "build_document", return_value="doc", create=True), \
+             patch.object(app_module, "embed_text", return_value=[0.1] * 768, create=True):
+            # news_collector 에서 lazy import 하므로 직접 패치
+            with patch.dict("sys.modules", {
+                "embedding": MagicMock(
+                    build_document=MagicMock(return_value="doc"),
+                    embed_text=MagicMock(return_value=[0.1] * 768),
+                ),
+            }):
+                result = app_module.news_collector({}, None)
+
+        assert json.loads(result["body"])["saved"] == 1
+
+    @patch("app.NaverNewsCollector")
+    @patch("app._make_storage")
+    def test_handler_skips_existing_urls(self, mock_storage_fn, mock_collector_cls, monkeypatch):
+        monkeypatch.setenv("NAVER_CLIENT_ID", "test_id")
+        monkeypatch.setenv("NAVER_CLIENT_SECRET", "test_secret")
+
+        mock_storage = MagicMock()
+        mock_storage.get_all_urls.return_value = {"https://news.com/existing"}
+        mock_storage.bucket = "test-bucket"
+        mock_storage_fn.return_value = mock_storage
+
+        item = NewsItem(
+            company_name="카카오",
+            title="카카오 AI",
+            description="설명",
+            url="https://news.com/existing",
+            pub_date=datetime(2026, 4, 1, tzinfo=KST),
+            collected_at="2026-04-01T12:00:00+09:00",
+        )
+        mock_collector_cls.return_value.collect_all.return_value = [item]
+
+        import app as app_module
+        result = app_module.news_collector({}, None)
+
+        assert json.loads(result["body"])["skipped"] == 1
+        assert json.loads(result["body"])["saved"] == 0


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#41

## #️⃣ 작업 내용

네이버 뉴스 검색 API를 연동하여 주요 기업의 기술/사업 동향 뉴스를 수집하는 모듈과 Lambda 핸들러를 구현한다.

### 배경

JD만으로는 "이 기업이 어떤 기술/사업에 관심 있는가"를 파악하기 어렵다. 뉴스 동향을 결합하면 기업 맞춤형 면접 질문의 품질이 올라간다. 네이버 뉴스 검색 API는 무료(일 25,000회)이고, REST API로 구현이 간단하다.

### 변경 상세

| 파일 | 변경 내용 |
|------|----------|
| `src/collector/__init__.py` | collector 패키지 초기화 |
| `src/collector/naver_news.py` | 네이버 뉴스 검색 API 호출 모듈. 대기업/금융권/주요 IT 기업 70개 기업 목록, 검색어 접미사(`기술`, `AI`, `개발`) 조합 검색, 노이즈 필터링(제외 키워드 + 제목 관련성 필터), URL 중복 제거, pubDate 파싱, 90일 deadline 계산. |
| `src/app.py` | `news_collector` Lambda 핸들러 추가. 뉴스 수집 → 임베딩(KR-SBERT) → S3 저장(`parsed/naver_news/{id}.json`). 기존 URL 중복 스킵. |
| `tests/unit/test_naver_news.py` | 단위 테스트 29개. API 호출 mock, 노이즈 필터링, HTML 태그 제거, pubDate 파싱, 관련성 필터, URL 중복 제거, 핸들러 통합 테스트. |
| `scripts/news_smoke.py` | 로컬 스모크 테스트 스크립트. 환경변수로 API 키 주입, 기업 지정 가능. |

### 노이즈 필터링 전략

1. **제목 제외 키워드**: 주가, 주식, 인사, 소송, 선거 등 기술/사업과 무관한 기사 제거
2. **제목 관련성 필터**: 기업명이 제목에 포함되어야 통과. description에만 우연히 언급되는 기사(예: "카카오톡 대화 내용") 제거
3. **URL 중복 제거**: 기업 간, 검색어 간 동일 URL 제거

### 스모크 테스트 결과

카카오 1개 기업 기준 49건 수집. 필터링 전(195건) 대비 노이즈 대폭 감소.

```
카카오 PlayMCP, AI 에이전트 '오픈클로'와 연동… AI 생태계 넓힌다
카카오뱅크, '투자탭' 선봬
카카오모빌리티, 광고 컨퍼런스 성료…통합 플랫폼 비전 제시
...
```

### 데이터 흐름

```
[news_collector Lambda]
    │  1. 70개 기업 × 3 검색어 → 네이버 뉴스 API 호출
    │  2. 노이즈 필터링 + URL 중복 제거
    │  3. 임베딩 (KR-SBERT, 기존과 동일)
    │  4. S3에 JSON 저장 (parsed/naver_news/{id}.json)
    ▼
[S3 → Consumer → ChromaDB]  (기존 파이프라인 재사용, 수정 불필요)
```

### 90일 자동 삭제

뉴스 `deadline`을 `pubDate + 90일`의 Unix timestamp로 설정한다. 기존 `job_list_collector`가 매일 실행하는 마감 삭제 요청이 `deadline < now_ts` 조건으로 자동 삭제하므로, Consumer 수정 없이 동작한다.

### 추가 환경변수

| 이름 | 필수? | 설명 |
|------|-------|------|
| `NAVER_CLIENT_ID` | `news_collector`에서 필수 | 네이버 개발자 센터 클라이언트 ID |
| `NAVER_CLIENT_SECRET` | `news_collector`에서 필수 | 네이버 개발자 센터 클라이언트 Secret |

### 후속 작업

- SAM 템플릿에 `news_collector` Lambda + EventBridge 스케줄 추가
- GitHub Actions deploy workflow에 네이버 API 키 파라미터 전달 추가

## #️⃣ 테스트 결과

단위 테스트 85개 전체 통과 (뉴스 모듈 29개 포함, 기존 테스트 56개 영향 없음)

```
tests/unit/test_naver_news.py::TestStripHtml (4 tests) PASSED
tests/unit/test_naver_news.py::TestParsePubDate (2 tests) PASSED
tests/unit/test_naver_news.py::TestMakeExternalId (3 tests) PASSED
tests/unit/test_naver_news.py::TestIsNoise (7 tests) PASSED
tests/unit/test_naver_news.py::TestIsRelevant (3 tests) PASSED
tests/unit/test_naver_news.py::TestDeadlineFromPubDate (1 test) PASSED
tests/unit/test_naver_news.py::TestNewsItemToDetailDict (1 test) PASSED
tests/unit/test_naver_news.py::TestNaverNewsCollector (6 tests) PASSED
tests/unit/test_naver_news.py::TestNewsCollectorHandler (2 tests) PASSED
======================== 85 passed in 1.18s =========================
```

## #️⃣ 변경 사항 체크리스트

- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## 📎 참고 자료 (선택)

- [네이버 뉴스 검색 API 문서](https://developers.naver.com/docs/serviceapi/search/news/news.md)
- [네이버 개발자 센터](https://developers.naver.com)