### PR TITLE
feat: 주요 IT 기업 기술 블로그 RSS 수집 파이프라인 구축

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -12,7 +12,6 @@ from datetime import datetime, timedelta, timezone
 import boto3
 
 from collector.naver_news import NaverNewsCollector, news_item_to_detail_dict
-from collector.tech_blog import TechBlogCollector, blog_article_to_detail_dict
 from crawler.base import ImageJobDetail, JobDetail, JobListingRef
 from crawler.registry import get_crawler, iter_sources
 from storage.s3 import S3Storage
@@ -193,6 +192,7 @@ def news_collector(event, context):
 
 def blog_collector(event, context):
     """주요 기업 기술 블로그 RSS 피드를 수집하여 S3 에 저장."""
+    from collector.tech_blog import TechBlogCollector, blog_article_to_detail_dict  # noqa: C0415
     from embedding import build_document, embed_text  # noqa: C0415
 
     storage = _make_storage()

--- a/src/app.py
+++ b/src/app.py
@@ -187,7 +187,7 @@ def news_collector(event, context):
     }
 
 
-# ── Lambda 4: 기��� 블로그 수집 (cron) ──
+# ── Lambda 4: 기술 블로그 수집 (cron) ──
 
 
 def blog_collector(event, context):

--- a/src/app.py
+++ b/src/app.py
@@ -2,6 +2,7 @@
 
 EventBridge cron → [job_list_collector] → SQS → [job_detail_crawler] → S3 → EC2 consumer → ChromaDB
 EventBridge cron → [news_collector] → S3 → EC2 consumer → ChromaDB
+EventBridge cron → [blog_collector] → S3 → EC2 consumer → ChromaDB
 """
 import json
 import logging
@@ -11,6 +12,7 @@ from datetime import datetime, timedelta, timezone
 import boto3
 
 from collector.naver_news import NaverNewsCollector, news_item_to_detail_dict
+from collector.tech_blog import TechBlogCollector, blog_article_to_detail_dict
 from crawler.base import ImageJobDetail, JobDetail, JobListingRef
 from crawler.registry import get_crawler, iter_sources
 from storage.s3 import S3Storage
@@ -180,6 +182,50 @@ def news_collector(event, context):
         saved += 1
 
     logger.info("뉴스 수집 완료: 저장 %d건, 중복 스킵 %d건", saved, skipped)
+    return {
+        "statusCode": 200,
+        "body": json.dumps({"saved": saved, "skipped": skipped}),
+    }
+
+
+# ── Lambda 4: 기��� 블로그 수집 (cron) ──
+
+
+def blog_collector(event, context):
+    """주요 기업 기술 블로그 RSS 피드를 수집하여 S3 에 저장."""
+    from embedding import build_document, embed_text  # noqa: C0415
+
+    storage = _make_storage()
+    existing_urls = storage.get_all_urls()
+
+    collector = TechBlogCollector()
+    articles = collector.collect_all()
+
+    saved = 0
+    skipped = 0
+    for article in articles:
+        if article.url in existing_urls:
+            skipped += 1
+            continue
+
+        data = blog_article_to_detail_dict(article)
+
+        try:
+            document = build_document(data["raw_text"], tuple(data["tech_stack"]))
+            embedding = embed_text(document)
+            data["embedding"] = embedding
+        except Exception:
+            logger.exception("임베딩 실패, 임베딩 없이 저장: id=%s", data["external_id"])
+
+        key = f"parsed/{data['source']}/{data['external_id']}.json"
+        storage.s3.put_object(
+            Bucket=storage.bucket,
+            Key=key,
+            Body=json.dumps(data, ensure_ascii=False).encode("utf-8"),
+        )
+        saved += 1
+
+    logger.info("블로그 수집 완료: 저장 %d건, 중복 스킵 %d건", saved, skipped)
     return {
         "statusCode": 200,
         "body": json.dumps({"saved": saved, "skipped": skipped}),

--- a/src/collector/tech_blog.py
+++ b/src/collector/tech_blog.py
@@ -203,7 +203,12 @@ def _classify_job_categories(text: str) -> list[str]:
     categories: list[str] = []
     for category, keywords in _JOB_CATEGORY_KEYWORDS.items():
         for kw in keywords:
-            if kw.lower() in text_lower:
+            kw_lower = kw.lower()
+            if len(kw_lower) <= 3:
+                if re.search(rf"\b{re.escape(kw_lower)}\b", text_lower):
+                    categories.append(category)
+                    break
+            elif kw_lower in text_lower:
                 categories.append(category)
                 break
     return categories

--- a/src/collector/tech_blog.py
+++ b/src/collector/tech_blog.py
@@ -1,9 +1,11 @@
-"""주요 IT 기업 기술 블로그 RSS 피드 수집 모듈.
+"""주요 IT 기업 기술 블로그 수집 모듈.
 
-22개 RSS/Atom 피드로 기술 블로그 글을 수집하여 면접 질문 생성에 활용한다.
+22개 RSS/Atom 피드 + SK 데보션(HTML 크롤링)으로 기술 블로그 글을 수집한다.
+RSS 요약이 잘린 경우 trafilatura → BeautifulSoup 순으로 본문을 직접 추출한다.
 """
 import hashlib
 import html
+import json
 import logging
 import re
 import time
@@ -12,12 +14,16 @@ from datetime import datetime, timedelta, timezone
 from email.utils import parsedate_to_datetime
 
 import feedparser
+import requests
+import trafilatura
+from bs4 import BeautifulSoup
 
 logger = logging.getLogger(__name__)
 
 KST = timezone(timedelta(hours=9))
 
 BLOG_RETENTION_DAYS = 730
+_MAX_FETCH_CONTENT = 5
 _FEED_FILTER_DAYS = timedelta(days=730)
 
 # ── 블로그 피드 설정 ──
@@ -54,6 +60,21 @@ _DEFAULT_FEEDS: tuple[BlogFeed, ...] = (
     BlogFeed("지마켓", "https://dev.gmarket.com/rss"),
     BlogFeed("11번가", "https://11st-tech.github.io/rss/"),
 )
+
+# ── SK 데보션 (HTML 크롤링) ──
+
+_DEVOCEAN_LIST_URL = "https://devocean.sk.com/blog/index.do?p=BLOG"
+_DEVOCEAN_DETAIL_URL = "https://devocean.sk.com/blog/techBoardDetail.do?ID={board_id}"
+_DEVOCEAN_COMPANY = "SK"
+_DEVOTEE_MARKER = "DEVOTEE 요약"
+
+_HTTP_HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+    ),
+    "Accept-Encoding": "identity",
+}
 
 # ── 피드 요청 간격 (초) ──
 
@@ -95,9 +116,98 @@ def _parse_pub_date(entry: dict) -> datetime:
     return datetime.now(KST)
 
 
+def _is_truncated(text: str) -> bool:
+    """본문 앞부분만 잘려서 들어온 요약인지 판별한다."""
+    return text.endswith("…") or text.endswith("...")
+
+
 def _make_external_id(url: str) -> str:
     """URL 에서 결정적 external_id 를 생성."""
     return hashlib.md5(url.encode()).hexdigest()[:12]
+
+
+def _parse_devocean_date(date_str: str) -> datetime:
+    """데보션 날짜 문자열(YY.MM.DD)을 datetime 으로 변환."""
+    try:
+        return datetime.strptime(date_str.strip(), "%y.%m.%d").replace(tzinfo=KST)
+    except (ValueError, AttributeError):
+        return datetime.now(KST)
+
+
+# ── 직무 카테고리 키워드 매핑 ──
+
+_JOB_CATEGORY_KEYWORDS: dict[str, tuple[str, ...]] = {
+    "백엔드개발자": (
+        "백엔드", "backend", "서버 개발", "Spring", "JPA", "Hibernate",
+        "Django", "FastAPI", "NestJS", "gRPC", "REST API", "MSA",
+        "마이크로서비스", "microservice", "트랜잭션", "transaction",
+    ),
+    "프론트엔드개발자": (
+        "프론트엔드", "frontend", "React", "Vue", "Angular", "Next.js",
+        "Nuxt", "웹뷰", "CSS", "컴포넌트", "UI ", "UX ",
+        "디자인 시스템", "design system",
+    ),
+    "웹개발자": (
+        "웹 개발", "web dev", "풀스택", "full-stack", "fullstack",
+        "HTML", "웹 성능", "웹 최적화",
+    ),
+    "앱개발자": (
+        "iOS", "Android", "Swift", "Kotlin", "Flutter", "React Native",
+        "모바일", "mobile", "앱 개발",
+    ),
+    "데이터엔지니어": (
+        "데이터 엔지니어", "data engineer", "Kafka", "Spark", "Airflow",
+        "ETL", "데이터 파이프라인", "data pipeline", "Flink", "Hadoop",
+        "데이터 웨어하우스", "StarRocks", "Presto", "Hive",
+    ),
+    "데이터사이언티스트": (
+        "데이터 사이언", "data scien", "데이터 분석", "data analy",
+        "A/B 테스트", "AB테스트", "추천 시스템", "recommendation",
+        "통계", "statistic", "지표", "metric",
+    ),
+    "소프트웨어개발자": (
+        "소프트웨어 개발", "software dev", "리팩토링", "refactor",
+        "코드 리뷰", "code review", "아키텍처", "architecture",
+        "모노레포", "monorepo", "레거시", "legacy",
+    ),
+    "게임개발자": (
+        "게임 개발", "game dev", "Unity", "Unreal", "렌더링", "rendering",
+        "게임 서버", "게임 클라이언트",
+    ),
+    "AI/ML엔지니어": (
+        "AI", "ML", "딥러닝", "deep learning", "LLM", "GPT", "Claude",
+        "모델 학습", "model training", "신경망", "neural",
+        "transformer", "파인튜닝", "fine-tun", "임베딩", "embedding",
+        "RAG", "벡터", "vector",
+    ),
+    "클라우드엔지니어": (
+        "AWS", "GCP", "Azure", "Kubernetes", "k8s", "Docker",
+        "클라우드", "cloud", "인프라", "infra", "DevOps", "데브옵스",
+        "Terraform", "CI/CD", "SRE", "모니터링", "monitoring",
+    ),
+    "MLOps엔지니어": (
+        "MLOps", "모델 서빙", "model serving", "SageMaker",
+        "ML 파이프라인", "ML pipeline", "모델 배포", "model deploy",
+        "ONNX", "TensorRT",
+    ),
+    "AI서비스개발자": (
+        "AI 서비스", "AI 에이전트", "AI agent", "챗봇", "chatbot",
+        "프롬프트", "prompt", "생성형 AI", "generative AI",
+        "바이브코딩", "vibe coding", "AI 코딩", "Copilot",
+    ),
+}
+
+
+def _classify_job_categories(text: str) -> list[str]:
+    """텍스트에서 키워드를 찾아 관련 직무 카테고리를 반환한다."""
+    text_lower = text.lower()
+    categories: list[str] = []
+    for category, keywords in _JOB_CATEGORY_KEYWORDS.items():
+        for kw in keywords:
+            if kw.lower() in text_lower:
+                categories.append(category)
+                break
+    return categories
 
 
 def _deadline_from_pub_date(pub_date: datetime) -> int:
@@ -106,8 +216,61 @@ def _deadline_from_pub_date(pub_date: datetime) -> int:
     return int(expiry.timestamp())
 
 
+def _has_meaningful_content(text: str) -> bool:
+    """추출된 텍스트가 네비게이션 노이즈가 아닌 실제 본문인지 판별."""
+    avg_line_len = len(text) / max(text.count("\n") + 1, 1)
+    return avg_line_len > 30
+
+
+def _fetch_page_content(url: str) -> str:
+    """URL 에서 본문 텍스트를 추출한다. trafilatura → BeautifulSoup 순으로 시도."""
+    try:
+        resp = requests.get(url, headers=_HTTP_HEADERS, timeout=15)
+        resp.raise_for_status()
+    except Exception:
+        logger.exception("페이지 요청 실패: %s", url)
+        return ""
+
+    if resp.encoding and resp.encoding.lower() != "utf-8":
+        resp.encoding = "utf-8"
+
+    text = trafilatura.extract(resp.text)
+    if text and len(text) > 200 and _has_meaningful_content(text):
+        return text
+
+    soup = BeautifulSoup(resp.text, "html.parser")
+
+    # Nuxt/Next.js JSON 데이터에서 본문 추출 (카카오 등)
+    for script in soup.find_all("script"):
+        script_text = script.get_text()
+        if '"content":' not in script_text or len(script_text) < 5000:
+            continue
+        arr_start = script_text.find('[["ShallowReactive"')
+        if arr_start < 0:
+            continue
+        try:
+            data = json.loads(script_text[arr_start:])
+            content_idx_match = re.search(r'"content":\s*(\d+)', script_text)
+            if content_idx_match:
+                idx = int(content_idx_match.group(1))
+                if isinstance(data, list) and len(data) > idx:
+                    content = data[idx]
+                    if isinstance(content, str) and len(content) > 100:
+                        return _strip_html(content)
+        except (json.JSONDecodeError, IndexError, ValueError):
+            pass
+
+    # 일반 article/content 영역 추출
+    for selector in ["article", "[class*=content]", "[class*=post]", "main"]:
+        el = soup.select_one(selector)
+        if el and len(el.get_text(strip=True)) > 200:
+            return el.get_text(separator="\n", strip=True)
+
+    return ""
+
+
 class TechBlogCollector:
-    """RSS/Atom 피드를 사용해 기업 기술 블로그 글을 수집한다."""
+    """RSS/Atom 피드 + SK 데보션으로 기업 기술 블로그 글을 수집한다."""
 
     def __init__(
         self,
@@ -147,6 +310,8 @@ class TechBlogCollector:
             ]
 
         articles: list[BlogArticle] = []
+        fetch_count = 0
+
         for entry in entries:
             url = entry.get("link", "")
             if not url:
@@ -159,8 +324,18 @@ class TechBlogCollector:
             summary_raw = entry.get("summary") or entry.get("description") or ""
             summary = _strip_html(summary_raw)
 
-            if not summary:
-                continue
+            needs_fetch = not summary or _is_truncated(summary)
+
+            if needs_fetch and fetch_count < _MAX_FETCH_CONTENT:
+                content = _fetch_page_content(url)
+                if content:
+                    summary = content
+                else:
+                    summary = ""
+                fetch_count += 1
+                time.sleep(self.request_delay)
+            elif needs_fetch:
+                summary = ""
 
             articles.append(BlogArticle(
                 company_name=feed.company_name,
@@ -173,8 +348,107 @@ class TechBlogCollector:
 
         return articles
 
+    def _fetch_devocean(self) -> list[BlogArticle]:
+        """SK 데보션 블로그를 HTML 크롤링으로 수집한다."""
+        now_iso = datetime.now(KST).isoformat()
+
+        try:
+            resp = requests.get(
+                _DEVOCEAN_LIST_URL, headers=_HTTP_HEADERS, timeout=15,
+            )
+            resp.raise_for_status()
+        except Exception:
+            logger.exception("데보션 목록 페이지 요청 실패")
+            return []
+
+        soup = BeautifulSoup(resp.text, "html.parser")
+        board_elements = soup.find_all(attrs={"data-board-id": True})
+
+        seen_ids: set[str] = set()
+        board_ids: list[str] = []
+        titles: dict[str, str] = {}
+        dates: dict[str, str] = {}
+
+        for el in board_elements:
+            bid = el.get("data-board-id")
+            if bid in seen_ids:
+                continue
+            seen_ids.add(bid)
+            board_ids.append(bid)
+
+            card = el
+            for _ in range(5):
+                if card.parent:
+                    card = card.parent
+                if len(card.get_text(strip=True)) > 50:
+                    break
+
+            title_el = card.find(class_=re.compile(r"tit|title|subject"))
+            titles[bid] = title_el.get_text(strip=True) if title_el else ""
+
+            date_el = card.find(class_=re.compile(r"date|time"))
+            dates[bid] = date_el.get_text(strip=True) if date_el else ""
+
+        articles: list[BlogArticle] = []
+        for bid in board_ids:
+            title = titles.get(bid, "")
+            if not title:
+                continue
+
+            detail_url = _DEVOCEAN_DETAIL_URL.format(board_id=bid)
+            summary = self._fetch_devocean_summary(detail_url)
+            if not summary:
+                continue
+
+            pub_date = _parse_devocean_date(dates.get(bid, ""))
+
+            articles.append(BlogArticle(
+                company_name=_DEVOCEAN_COMPANY,
+                title=title,
+                summary=summary,
+                url=detail_url,
+                pub_date=pub_date,
+                collected_at=now_iso,
+            ))
+
+            time.sleep(self.request_delay)
+
+        return articles
+
+    def _fetch_devocean_summary(self, detail_url: str) -> str:
+        """데보션 상세 페이지에서 DEVOTEE 요약을 추출한다."""
+        try:
+            resp = requests.get(detail_url, headers=_HTTP_HEADERS, timeout=15)
+            resp.raise_for_status()
+        except Exception:
+            logger.exception("데보션 상세 페이지 요청 실패: %s", detail_url)
+            return ""
+
+        soup = BeautifulSoup(resp.text, "html.parser")
+        view = soup.select_one(".sub-view-cont")
+        if not view:
+            return ""
+
+        text = view.get_text(separator="\n", strip=True)
+        if _DEVOTEE_MARKER not in text:
+            return ""
+
+        idx = text.index(_DEVOTEE_MARKER) + len(_DEVOTEE_MARKER)
+        after = text[idx:].strip()
+
+        lines: list[str] = []
+        for line in after.split("\n"):
+            stripped = line.strip()
+            if not stripped:
+                if lines:
+                    break
+                continue
+            lines.append(stripped)
+
+        return " ".join(lines)
+
     def collect_all(self) -> list[BlogArticle]:
-        """전체 피드에서 블로그 글을 수집한다. URL 기준 전역 중복 제거."""
+        """전체 피드 + SK 데보션에서 블로그 글을 수집한다. URL 기준 전역 중복 제거."""
         all_articles: list[BlogArticle] = []
         global_seen_urls: set[str] = set()
 
@@ -190,8 +464,17 @@ class TechBlogCollector:
 
             time.sleep(self.request_delay)
 
+        devocean_articles = self._fetch_devocean()
+        for article in devocean_articles:
+            if article.url in global_seen_urls:
+                continue
+            global_seen_urls.add(article.url)
+            all_articles.append(article)
+
+        logger.info("feed=SK 데보션: %d건 수집", len(devocean_articles))
+
         logger.info(
-            "전체 블로그 수집 완료: %d건 (피드 %d개)",
+            "전체 블로그 수집 완료: %d건 (RSS %d개 + SK 데보션)",
             len(all_articles), len(self.feeds),
         )
         return all_articles
@@ -199,7 +482,13 @@ class TechBlogCollector:
 
 def blog_article_to_detail_dict(article: BlogArticle) -> dict:
     """BlogArticle 을 S3 저장용 dict 로 변환. JobDetail 호환 형식."""
-    raw_text = f"{article.title}\n\n{article.summary}" if article.summary else article.title
+    content = f"{article.title}\n\n{article.summary}" if article.summary else article.title
+    categories = _classify_job_categories(content)
+
+    raw_text = content
+    if categories:
+        raw_text += f"\n\n[직무]\n{', '.join(categories)}"
+
     return {
         "source": "tech_blog",
         "external_id": _make_external_id(article.url),

--- a/src/collector/tech_blog.py
+++ b/src/collector/tech_blog.py
@@ -1,0 +1,214 @@
+"""주요 IT 기업 기술 블로그 RSS 피드 수집 모듈.
+
+22개 RSS/Atom 피드로 기술 블로그 글을 수집하여 면접 질문 생성에 활용한다.
+"""
+import hashlib
+import html
+import logging
+import re
+import time
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from email.utils import parsedate_to_datetime
+
+import feedparser
+
+logger = logging.getLogger(__name__)
+
+KST = timezone(timedelta(hours=9))
+
+BLOG_RETENTION_DAYS = 730
+_FEED_FILTER_DAYS = timedelta(days=730)
+
+# ── 블로그 피드 설정 ──
+
+
+@dataclass(frozen=True)
+class BlogFeed:
+    """RSS/Atom 피드 1개."""
+    company_name: str
+    feed_url: str
+
+
+_DEFAULT_FEEDS: tuple[BlogFeed, ...] = (
+    BlogFeed("네이버", "https://d2.naver.com/d2.atom"),
+    BlogFeed("카카오", "https://tech.kakao.com/feed"),
+    BlogFeed("카카오페이", "https://tech.kakaopay.com/rss.xml"),
+    BlogFeed("카카오뱅크", "https://tech.kakaobank.com/index.xml"),
+    BlogFeed("토스", "https://toss.tech/rss.xml"),
+    BlogFeed("우아한형제들", "https://techblog.woowahan.com/feed"),
+    BlogFeed("당근", "https://medium.com/feed/daangn"),
+    BlogFeed("쿠팡", "https://medium.com/feed/coupang-engineering"),
+    BlogFeed("라인", "https://techblog.lycorp.co.jp/ko/feed/index.xml"),
+    BlogFeed("삼성전자", "https://techblog.samsung.com/rss"),
+    BlogFeed("LG U+", "https://techblog.uplus.co.kr/feed"),
+    BlogFeed("KT Cloud", "https://tech.ktcloud.com/feed"),
+    BlogFeed("NHN", "https://meetup.nhncloud.com/rss"),
+    BlogFeed("마켓컬리", "https://helloworld.kurly.com/rss.xml"),
+    BlogFeed("올리브영", "https://oliveyoung.tech/rss.xml"),
+    BlogFeed("무신사", "https://medium.com/feed/musinsa-tech"),
+    BlogFeed("뱅크샐러드", "https://blog.banksalad.com/rss.xml"),
+    BlogFeed("야놀자", "https://medium.com/feed/yanoljacloud-tech"),
+    BlogFeed("쏘카", "https://tech.socarcorp.kr/feed.xml"),
+    BlogFeed("넷마블", "https://netmarble.engineering/feed/"),
+    BlogFeed("지마켓", "https://dev.gmarket.com/rss"),
+    BlogFeed("11번가", "https://11st-tech.github.io/rss/"),
+)
+
+# ── 피드 요청 간격 (초) ──
+
+_DEFAULT_REQUEST_DELAY = 0.5
+
+
+@dataclass(frozen=True)
+class BlogArticle:
+    """블로그 글 1건."""
+    company_name: str
+    title: str
+    summary: str
+    url: str
+    pub_date: datetime
+    collected_at: str
+
+
+def _strip_html(text: str) -> str:
+    """HTML 태그와 엔티티를 제거한다."""
+    cleaned = re.sub(r"<[^>]+>", "", text)
+    return html.unescape(cleaned).strip()
+
+
+def _parse_pub_date(entry: dict) -> datetime:
+    """feedparser 엔트리에서 발행일을 추출한다."""
+    published = entry.get("published") or entry.get("updated") or ""
+    if not published:
+        return datetime.now(KST)
+    try:
+        return parsedate_to_datetime(published)
+    except (ValueError, TypeError):
+        pass
+    try:
+        if hasattr(entry, "published_parsed") and entry.published_parsed:
+            from calendar import timegm
+            return datetime.fromtimestamp(timegm(entry.published_parsed), tz=timezone.utc)
+    except (ValueError, TypeError, OverflowError):
+        pass
+    return datetime.now(KST)
+
+
+def _make_external_id(url: str) -> str:
+    """URL 에서 결정적 external_id 를 생성."""
+    return hashlib.md5(url.encode()).hexdigest()[:12]
+
+
+def _deadline_from_pub_date(pub_date: datetime) -> int:
+    """pub_date + 730일을 Unix timestamp 로 변환."""
+    expiry = pub_date + timedelta(days=BLOG_RETENTION_DAYS)
+    return int(expiry.timestamp())
+
+
+class TechBlogCollector:
+    """RSS/Atom 피드를 사용해 기업 기술 블로그 글을 수집한다."""
+
+    def __init__(
+        self,
+        *,
+        feeds: tuple[BlogFeed, ...] | None = None,
+        request_delay: float = _DEFAULT_REQUEST_DELAY,
+    ):
+        self.feeds = feeds or _DEFAULT_FEEDS
+        self.request_delay = request_delay
+
+    def _fetch_feed(self, feed: BlogFeed) -> list[BlogArticle]:
+        """한 피드의 글을 수집한다."""
+        now_iso = datetime.now(KST).isoformat()
+        now = datetime.now(KST)
+
+        try:
+            parsed = feedparser.parse(feed.feed_url)
+        except Exception:
+            logger.exception("피드 파싱 실패: %s (%s)", feed.company_name, feed.feed_url)
+            return []
+
+        if parsed.bozo and not parsed.entries:
+            logger.warning(
+                "피드 오류 (항목 없음): %s (%s) — %s",
+                feed.company_name, feed.feed_url, parsed.bozo_exception,
+            )
+            return []
+
+        entries = parsed.entries
+
+        # 20건 초과 피드는 최근 2년 이내 글만
+        if len(entries) > 20:
+            cutoff = now - _FEED_FILTER_DAYS
+            entries = [
+                e for e in entries
+                if _parse_pub_date(e) >= cutoff
+            ]
+
+        articles: list[BlogArticle] = []
+        for entry in entries:
+            url = entry.get("link", "")
+            if not url:
+                continue
+
+            title = _strip_html(entry.get("title", ""))
+            if not title:
+                continue
+
+            summary_raw = entry.get("summary") or entry.get("description") or ""
+            summary = _strip_html(summary_raw)
+
+            if not summary:
+                continue
+
+            articles.append(BlogArticle(
+                company_name=feed.company_name,
+                title=title,
+                summary=summary,
+                url=url,
+                pub_date=_parse_pub_date(entry),
+                collected_at=now_iso,
+            ))
+
+        return articles
+
+    def collect_all(self) -> list[BlogArticle]:
+        """전체 피드에서 블로그 글을 수집한다. URL 기준 전역 중복 제거."""
+        all_articles: list[BlogArticle] = []
+        global_seen_urls: set[str] = set()
+
+        for feed in self.feeds:
+            articles = self._fetch_feed(feed)
+            for article in articles:
+                if article.url in global_seen_urls:
+                    continue
+                global_seen_urls.add(article.url)
+                all_articles.append(article)
+
+            logger.info("feed=%s: %d건 수집", feed.company_name, len(articles))
+
+            time.sleep(self.request_delay)
+
+        logger.info(
+            "전체 블로그 수집 완료: %d건 (피드 %d개)",
+            len(all_articles), len(self.feeds),
+        )
+        return all_articles
+
+
+def blog_article_to_detail_dict(article: BlogArticle) -> dict:
+    """BlogArticle 을 S3 저장용 dict 로 변환. JobDetail 호환 형식."""
+    raw_text = f"{article.title}\n\n{article.summary}" if article.summary else article.title
+    return {
+        "source": "tech_blog",
+        "external_id": _make_external_id(article.url),
+        "url": article.url,
+        "company_name": article.company_name,
+        "title": article.title,
+        "raw_text": raw_text,
+        "tech_stack": [],
+        "deadline": _deadline_from_pub_date(article.pub_date),
+        "crawled_at": article.collected_at,
+        "career_level": "",
+    }

--- a/src/collector/tech_blog.py
+++ b/src/collector/tech_blog.py
@@ -237,8 +237,7 @@ def _fetch_page_content(url: str) -> str:
         logger.exception("페이지 요청 실패: %s", url)
         return ""
 
-    if resp.encoding and resp.encoding.lower() != "utf-8":
-        resp.encoding = "utf-8"
+    resp.encoding = resp.apparent_encoding
 
     text = trafilatura.extract(resp.text)
     if text and len(text) > 200 and _has_meaningful_content(text):

--- a/src/collector/tech_blog.py
+++ b/src/collector/tech_blog.py
@@ -15,7 +15,6 @@ from email.utils import parsedate_to_datetime
 
 import feedparser
 import requests
-import trafilatura
 from bs4 import BeautifulSoup
 
 logger = logging.getLogger(__name__)
@@ -224,6 +223,8 @@ def _has_meaningful_content(text: str) -> bool:
 
 def _fetch_page_content(url: str) -> str:
     """URL 에서 본문 텍스트를 추출한다. trafilatura → BeautifulSoup 순으로 시도."""
+    import trafilatura  # noqa: C0415
+
     try:
         resp = requests.get(url, headers=_HTTP_HEADERS, timeout=15)
         resp.raise_for_status()

--- a/src/requirements-full.txt
+++ b/src/requirements-full.txt
@@ -1,5 +1,7 @@
 requests
 beautifulsoup4
+feedparser
+trafilatura
 onnxruntime
 transformers
 numpy<2

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,2 +1,3 @@
 requests
 beautifulsoup4
+feedparser

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,3 +1,4 @@
 requests
 beautifulsoup4
 feedparser
+trafilatura

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,4 +1,2 @@
 requests
 beautifulsoup4
-feedparser
-trafilatura

--- a/template.yaml
+++ b/template.yaml
@@ -166,6 +166,30 @@ Resources:
       DockerContext: .
       Dockerfile: src/Dockerfile
 
+  # ── Lambda 4: 기술 블로그 수집 (cron) ──
+  BlogCollector:
+    Type: AWS::Serverless::Function
+    Properties:
+      PackageType: Image
+      Timeout: 900
+      MemorySize: 1536
+      ImageConfig:
+        Command:
+          - app.blog_collector
+      Policies:
+        - S3CrudPolicy:
+            BucketName: !Ref CrawlerDataBucket
+      Events:
+        DailySchedule:
+          Type: Schedule
+          Properties:
+            Schedule: cron(0 20 * * ? *)
+            Enabled: false
+    Metadata:
+      DockerTag: python3.11
+      DockerContext: .
+      Dockerfile: src/Dockerfile
+
   # ── Lambda 2: 상세 크롤러 + 임베딩 (컨테이너 이미지) ──
   JobDetailCrawler:
     Type: AWS::Serverless::Function
@@ -206,6 +230,9 @@ Outputs:
   NewsCollectorArn:
     Description: 뉴스 수집 Lambda ARN
     Value: !GetAtt NewsCollector.Arn
+  BlogCollectorArn:
+    Description: 블로그 수집 Lambda ARN
+    Value: !GetAtt BlogCollector.Arn
   DLQAlarmTopicArn:
     Description: DLQ 알람 SNS 토픽 ARN
     Value: !Ref DLQAlarmTopic

--- a/tests/unit/test_tech_blog.py
+++ b/tests/unit/test_tech_blog.py
@@ -3,8 +3,6 @@ import json
 from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from collector.tech_blog import (
     BLOG_RETENTION_DAYS,
     BlogArticle,

--- a/tests/unit/test_tech_blog.py
+++ b/tests/unit/test_tech_blog.py
@@ -3,13 +3,19 @@ import json
 from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from collector.tech_blog import (
     BLOG_RETENTION_DAYS,
     BlogArticle,
     BlogFeed,
     TechBlogCollector,
+    _classify_job_categories,
     _deadline_from_pub_date,
+    _fetch_page_content,
+    _is_truncated,
     _make_external_id,
+    _parse_devocean_date,
     _strip_html,
     blog_article_to_detail_dict,
 )
@@ -43,6 +49,29 @@ class TestMakeExternalId:
 
     def test_different_urls_differ(self):
         assert _make_external_id("https://a.com") != _make_external_id("https://b.com")
+
+
+class TestClassifyJobCategories:
+    def test_backend_keywords(self):
+        cats = _classify_job_categories("Spring Boot 기반 MSA 전환기")
+        assert "백엔드개발자" in cats
+
+    def test_frontend_keywords(self):
+        cats = _classify_job_categories("React 컴포넌트 디자인 시스템 구축")
+        assert "프론트엔드개발자" in cats
+
+    def test_ai_ml_keywords(self):
+        cats = _classify_job_categories("LLM 기반 RAG 파이프라인 구축")
+        assert "AI/ML엔지니어" in cats
+
+    def test_multiple_categories(self):
+        cats = _classify_job_categories("Kubernetes 위에서 ML 모델 서빙하기")
+        assert "클라우드엔지니어" in cats
+        assert "MLOps엔지니어" in cats
+
+    def test_no_match(self):
+        cats = _classify_job_categories("회사 워크숍 후기")
+        assert cats == []
 
 
 class TestDeadlineFromPubDate:
@@ -82,7 +111,7 @@ class TestBlogArticleToDetailDict:
 
     def test_raw_text_title_only_when_no_summary(self):
         data = blog_article_to_detail_dict(_article(summary=""))
-        assert data["raw_text"] == "Kafka 파티션 전략"
+        assert data["raw_text"].startswith("Kafka 파티션 전략")
 
     def test_deadline_is_unix_timestamp(self):
         data = blog_article_to_detail_dict(_article())
@@ -96,6 +125,17 @@ class TestBlogArticleToDetailDict:
     def test_career_level_empty(self):
         data = blog_article_to_detail_dict(_article())
         assert data["career_level"] == ""
+
+    def test_raw_text_includes_job_categories(self):
+        data = blog_article_to_detail_dict(_article())
+        assert "[직무]" in data["raw_text"]
+        assert "데이터엔지니어" in data["raw_text"]
+
+    def test_no_job_section_when_no_match(self):
+        data = blog_article_to_detail_dict(_article(
+            title="회사 워크숍 후기", summary="즐거운 시간이었습니다.",
+        ))
+        assert "[직무]" not in data["raw_text"]
 
 
 # ─────────────────────────────────────────────────────────
@@ -120,10 +160,37 @@ def _feed_entry(title="테스트 글", url="https://blog.test/1", summary="요�
     }
 
 
+class TestIsTruncated:
+    def test_ellipsis_unicode(self):
+        assert _is_truncated("안녕하세요 카카오…") is True
+
+    def test_ellipsis_dots(self):
+        assert _is_truncated("내용이 잘려서...") is True
+
+    def test_complete_sentence(self):
+        assert _is_truncated("이 글에서는 기술을 소개합니다.") is False
+
+    def test_empty_string(self):
+        assert _is_truncated("") is False
+
+
+class TestParseDevoceanDate:
+    def test_valid_date(self):
+        dt = _parse_devocean_date("26.04.30")
+        assert dt.year == 2026
+        assert dt.month == 4
+        assert dt.day == 30
+
+    def test_invalid_date_returns_now(self):
+        dt = _parse_devocean_date("invalid")
+        assert dt.year >= 2026
+
+
 class TestTechBlogCollector:
+    @patch("collector.tech_blog.TechBlogCollector._fetch_devocean", return_value=[])
     @patch("collector.tech_blog.feedparser.parse")
     @patch("collector.tech_blog.time.sleep")
-    def test_collect_all_deduplicates_by_url(self, mock_sleep, mock_parse):
+    def test_collect_all_deduplicates_by_url(self, mock_sleep, mock_parse, mock_devocean):
         """동일 URL 이 여러 피드에 있어도 1건만 수집."""
         same_url = "https://blog.test/shared"
         mock_parse.return_value = _mock_feed_result([
@@ -140,9 +207,10 @@ class TestTechBlogCollector:
         assert len(articles) == 1
         assert articles[0].url == same_url
 
+    @patch("collector.tech_blog.TechBlogCollector._fetch_devocean", return_value=[])
     @patch("collector.tech_blog.feedparser.parse")
     @patch("collector.tech_blog.time.sleep")
-    def test_collect_all_skips_entries_without_link(self, mock_sleep, mock_parse):
+    def test_collect_all_skips_entries_without_link(self, mock_sleep, mock_parse, mock_devocean):
         """link 가 없는 항목은 스킵."""
         mock_parse.return_value = _mock_feed_result([
             {"title": "제목만", "summary": "요약"},
@@ -155,13 +223,34 @@ class TestTechBlogCollector:
 
         assert len(articles) == 1
 
+    @patch("collector.tech_blog._fetch_page_content", return_value="본문 내용입니다.")
+    @patch("collector.tech_blog.TechBlogCollector._fetch_devocean", return_value=[])
     @patch("collector.tech_blog.feedparser.parse")
     @patch("collector.tech_blog.time.sleep")
-    def test_collect_all_skips_entries_without_summary(self, mock_sleep, mock_parse):
-        """요약이 없는 항목은 스킵."""
+    def test_truncated_summary_fetches_page_content(self, mock_sleep, mock_parse, mock_devocean, mock_fetch):
+        """잘린 요약은 페이지 본문을 가져와서 대체한다."""
         mock_parse.return_value = _mock_feed_result([
-            _feed_entry(title="요약 없음", url="https://blog.test/no-summary", summary=""),
-            _feed_entry(title="정상 글", url="https://blog.test/ok", summary="요약 있음"),
+            _feed_entry(title="잘린 글", url="https://blog.test/truncated", summary="안녕하세요…"),
+            _feed_entry(title="정상 글", url="https://blog.test/ok", summary="완결된 요약입니다."),
+        ])
+
+        feeds = (BlogFeed("테스트", "https://test.com/feed"),)
+        collector = TechBlogCollector(feeds=feeds, request_delay=0)
+        articles = collector.collect_all()
+
+        assert len(articles) == 2
+        assert articles[0].summary == "본문 내용입니다."
+        assert articles[1].summary == "완결된 요약입니다."
+        mock_fetch.assert_called_once_with("https://blog.test/truncated")
+
+    @patch("collector.tech_blog._fetch_page_content", return_value="")
+    @patch("collector.tech_blog.TechBlogCollector._fetch_devocean", return_value=[])
+    @patch("collector.tech_blog.feedparser.parse")
+    @patch("collector.tech_blog.time.sleep")
+    def test_truncated_summary_falls_back_to_empty(self, mock_sleep, mock_parse, mock_devocean, mock_fetch):
+        """페이지 본문 추출도 실패하면 빈 요약으로 저장 (제목만)."""
+        mock_parse.return_value = _mock_feed_result([
+            _feed_entry(title="잘린 글", url="https://blog.test/truncated", summary="안녕하세요…"),
         ])
 
         feeds = (BlogFeed("테스트", "https://test.com/feed"),)
@@ -169,17 +258,137 @@ class TestTechBlogCollector:
         articles = collector.collect_all()
 
         assert len(articles) == 1
-        assert articles[0].title == "정상 글"
+        assert articles[0].summary == ""
 
+    @patch("collector.tech_blog._fetch_page_content", return_value="본문")
+    @patch("collector.tech_blog.TechBlogCollector._fetch_devocean", return_value=[])
     @patch("collector.tech_blog.feedparser.parse")
     @patch("collector.tech_blog.time.sleep")
-    def test_collect_all_handles_feed_error(self, mock_sleep, mock_parse):
+    def test_fetch_content_limited_to_max(self, mock_sleep, mock_parse, mock_devocean, mock_fetch):
+        """본문 추출은 최대 5건까지만 수행."""
+        entries = [
+            _feed_entry(title=f"글{i}", url=f"https://blog.test/{i}", summary="잘림…")
+            for i in range(10)
+        ]
+        mock_parse.return_value = _mock_feed_result(entries)
+
+        feeds = (BlogFeed("테스트", "https://test.com/feed"),)
+        collector = TechBlogCollector(feeds=feeds, request_delay=0)
+        articles = collector.collect_all()
+
+        assert mock_fetch.call_count == 5
+        fetched = [a for a in articles if a.summary == "본문"]
+        not_fetched = [a for a in articles if a.summary == ""]
+        assert len(fetched) == 5
+        assert len(not_fetched) == 5
+
+    @patch("collector.tech_blog.TechBlogCollector._fetch_devocean", return_value=[])
+    @patch("collector.tech_blog.feedparser.parse")
+    @patch("collector.tech_blog.time.sleep")
+    def test_collect_all_handles_feed_error(self, mock_sleep, mock_parse, mock_devocean):
         """피드 파싱 예외 시 해당 피드를 스킵하고 계속 진행."""
         mock_parse.side_effect = Exception("network error")
 
         feeds = (BlogFeed("에러피드", "https://error.com/feed"),)
         collector = TechBlogCollector(feeds=feeds, request_delay=0)
         articles = collector.collect_all()
+
+        assert articles == []
+
+
+# ─────────────────────────────────────────────────────────
+# SK 데보션 크롤링 테스트
+# ─────────────────────────────────────────────────────────
+
+
+_DEVOCEAN_LIST_HTML = """
+<html><body>
+<div>
+  <div data-board-id="100">
+    <strong class="tit">AI 모델 서빙 가이드</strong>
+    <span class="date">26.04.24</span>
+  </div>
+  <div data-board-id="100"><span class="tit">AI 모델 서빙 가이드</span></div>
+  <div data-board-id="200">
+    <strong class="tit">Kafka 최적화 사례</strong>
+    <span class="date">26.03.15</span>
+  </div>
+  <div data-board-id="200"><span class="tit">Kafka 최적화 사례</span></div>
+</div>
+</body></html>
+"""
+
+_DEVOCEAN_DETAIL_HTML = """
+<html><body>
+<div class="sub-view-cont">
+DEVOTEE 요약
+본 블로그는 AI 모델 서빙 파이프라인 구축 경험을 공유합니다.
+CDK와 API Gateway를 활용한 실전 가이드입니다.
+
+이 글은 실제 프로덕션에서 운영을 위해 개발을 진행했던 프로젝트 기반입니다.
+</div>
+</body></html>
+"""
+
+_DEVOCEAN_DETAIL_NO_DEVOTEE = """
+<html><body>
+<div class="sub-view-cont">
+이 글에는 AI 요약 기능이 적용되지 않았습니다. 본문만 있습니다.
+</div>
+</body></html>
+"""
+
+
+class TestDevocean:
+    @patch("collector.tech_blog.requests.get")
+    @patch("collector.tech_blog.time.sleep")
+    def test_fetch_devocean_extracts_devotee_summary(self, mock_sleep, mock_get):
+        """데보션 목록 + 상세에서 DEVOTEE 요약을 추출한다."""
+        list_resp = MagicMock()
+        list_resp.text = _DEVOCEAN_LIST_HTML
+        list_resp.raise_for_status = MagicMock()
+
+        detail_resp = MagicMock()
+        detail_resp.text = _DEVOCEAN_DETAIL_HTML
+        detail_resp.raise_for_status = MagicMock()
+
+        mock_get.side_effect = [list_resp, detail_resp, detail_resp]
+
+        collector = TechBlogCollector(feeds=(), request_delay=0)
+        articles = collector._fetch_devocean()
+
+        assert len(articles) == 2
+        assert articles[0].company_name == "SK"
+        assert articles[0].title == "AI 모델 서빙 가이드"
+        assert "AI 모델 서빙 파이프라인" in articles[0].summary
+
+    @patch("collector.tech_blog.requests.get")
+    @patch("collector.tech_blog.time.sleep")
+    def test_fetch_devocean_skips_without_devotee(self, mock_sleep, mock_get):
+        """DEVOTEE 요약이 없는 글은 스킵한다."""
+        list_resp = MagicMock()
+        list_resp.text = _DEVOCEAN_LIST_HTML
+        list_resp.raise_for_status = MagicMock()
+
+        no_devotee_resp = MagicMock()
+        no_devotee_resp.text = _DEVOCEAN_DETAIL_NO_DEVOTEE
+        no_devotee_resp.raise_for_status = MagicMock()
+
+        mock_get.side_effect = [list_resp, no_devotee_resp, no_devotee_resp]
+
+        collector = TechBlogCollector(feeds=(), request_delay=0)
+        articles = collector._fetch_devocean()
+
+        assert len(articles) == 0
+
+    @patch("collector.tech_blog.requests.get")
+    @patch("collector.tech_blog.time.sleep")
+    def test_fetch_devocean_handles_list_error(self, mock_sleep, mock_get):
+        """목록 페이지 요청 실패 시 빈 리스트 반환."""
+        mock_get.side_effect = Exception("connection error")
+
+        collector = TechBlogCollector(feeds=(), request_delay=0)
+        articles = collector._fetch_devocean()
 
         assert articles == []
 

--- a/tests/unit/test_tech_blog.py
+++ b/tests/unit/test_tech_blog.py
@@ -401,7 +401,7 @@ class TestDevocean:
 class TestBlogCollectorHandler:
     @patch("embedding.embed_text", return_value=[0.1] * 768)
     @patch("app.S3Storage")
-    @patch("app.TechBlogCollector")
+    @patch("collector.tech_blog.TechBlogCollector")
     def test_saves_new_articles(self, mock_collector_cls, mock_storage_cls, mock_embed):
         """신규 블로그 글이 S3 에 저장된다."""
         import app
@@ -423,7 +423,7 @@ class TestBlogCollectorHandler:
 
     @patch("embedding.embed_text", return_value=[0.1] * 768)
     @patch("app.S3Storage")
-    @patch("app.TechBlogCollector")
+    @patch("collector.tech_blog.TechBlogCollector")
     def test_skips_existing_urls(self, mock_collector_cls, mock_storage_cls, mock_embed):
         """이미 저장된 URL 은 스킵한다."""
         import app
@@ -445,7 +445,7 @@ class TestBlogCollectorHandler:
 
     @patch("embedding.embed_text", side_effect=RuntimeError("model error"))
     @patch("app.S3Storage")
-    @patch("app.TechBlogCollector")
+    @patch("collector.tech_blog.TechBlogCollector")
     def test_saves_without_embedding_on_failure(
         self, mock_collector_cls, mock_storage_cls, mock_embed,
     ):

--- a/tests/unit/test_tech_blog.py
+++ b/tests/unit/test_tech_blog.py
@@ -1,0 +1,262 @@
+"""tech_blog 수집 모듈 및 blog_collector Lambda 핸들러 단위 테스트."""
+import json
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+from collector.tech_blog import (
+    BLOG_RETENTION_DAYS,
+    BlogArticle,
+    BlogFeed,
+    TechBlogCollector,
+    _deadline_from_pub_date,
+    _make_external_id,
+    _strip_html,
+    blog_article_to_detail_dict,
+)
+
+KST = timezone(timedelta(hours=9))
+
+
+# ─────────────────────────────────────────────────────────
+# 헬퍼 함수 테스트
+# ─────────────────────────────────────────────────────────
+
+
+class TestStripHtml:
+    def test_removes_tags(self):
+        assert _strip_html("<p>hello <b>world</b></p>") == "hello world"
+
+    def test_unescapes_entities(self):
+        assert _strip_html("A &amp; B &lt;C&gt;") == "A & B <C>"
+
+    def test_empty_string(self):
+        assert _strip_html("") == ""
+
+
+class TestMakeExternalId:
+    def test_deterministic(self):
+        url = "https://tech.kakao.com/post/123"
+        assert _make_external_id(url) == _make_external_id(url)
+
+    def test_length_12(self):
+        assert len(_make_external_id("https://example.com")) == 12
+
+    def test_different_urls_differ(self):
+        assert _make_external_id("https://a.com") != _make_external_id("https://b.com")
+
+
+class TestDeadlineFromPubDate:
+    def test_adds_retention_days(self):
+        pub = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        expected = pub + timedelta(days=BLOG_RETENTION_DAYS)
+        assert _deadline_from_pub_date(pub) == int(expected.timestamp())
+
+
+# ─────────────────────────────────────────────────────────
+# blog_article_to_detail_dict 변환 테스트
+# ─────────────────────────────────────────────────────────
+
+
+def _article(**overrides) -> BlogArticle:
+    base = dict(
+        company_name="카카오",
+        title="Kafka 파티션 전략",
+        summary="대규모 트래픽 환경에서의 Kafka 파티션 최적화 사례를 공유합니다.",
+        url="https://tech.kakao.com/post/123",
+        pub_date=datetime(2026, 3, 15, 10, 0, tzinfo=KST),
+        collected_at="2026-05-02T10:00:00+09:00",
+    )
+    base.update(overrides)
+    return BlogArticle(**base)
+
+
+class TestBlogArticleToDetailDict:
+    def test_source_is_tech_blog(self):
+        data = blog_article_to_detail_dict(_article())
+        assert data["source"] == "tech_blog"
+
+    def test_raw_text_combines_title_and_summary(self):
+        data = blog_article_to_detail_dict(_article())
+        assert data["raw_text"].startswith("Kafka 파티션 전략")
+        assert "대규모 트래픽" in data["raw_text"]
+
+    def test_raw_text_title_only_when_no_summary(self):
+        data = blog_article_to_detail_dict(_article(summary=""))
+        assert data["raw_text"] == "Kafka 파티션 전략"
+
+    def test_deadline_is_unix_timestamp(self):
+        data = blog_article_to_detail_dict(_article())
+        assert isinstance(data["deadline"], int)
+        assert data["deadline"] > 0
+
+    def test_tech_stack_empty(self):
+        data = blog_article_to_detail_dict(_article())
+        assert data["tech_stack"] == []
+
+    def test_career_level_empty(self):
+        data = blog_article_to_detail_dict(_article())
+        assert data["career_level"] == ""
+
+
+# ─────────────────────────────────────────────────────────
+# TechBlogCollector 테스트
+# ─────────────────────────────────────────────────────────
+
+
+def _mock_feed_result(entries):
+    """feedparser.parse 의 반환값을 흉내내는 객체."""
+    result = MagicMock()
+    result.bozo = False
+    result.entries = entries
+    return result
+
+
+def _feed_entry(title="테스트 글", url="https://blog.test/1", summary="요약"):
+    return {
+        "title": title,
+        "link": url,
+        "summary": summary,
+        "published": "Sat, 01 Mar 2026 10:00:00 +0900",
+    }
+
+
+class TestTechBlogCollector:
+    @patch("collector.tech_blog.feedparser.parse")
+    @patch("collector.tech_blog.time.sleep")
+    def test_collect_all_deduplicates_by_url(self, mock_sleep, mock_parse):
+        """동일 URL 이 여러 피드에 있어도 1건만 수집."""
+        same_url = "https://blog.test/shared"
+        mock_parse.return_value = _mock_feed_result([
+            _feed_entry(url=same_url),
+        ])
+
+        feeds = (
+            BlogFeed("A사", "https://a.com/feed"),
+            BlogFeed("B사", "https://b.com/feed"),
+        )
+        collector = TechBlogCollector(feeds=feeds, request_delay=0)
+        articles = collector.collect_all()
+
+        assert len(articles) == 1
+        assert articles[0].url == same_url
+
+    @patch("collector.tech_blog.feedparser.parse")
+    @patch("collector.tech_blog.time.sleep")
+    def test_collect_all_skips_entries_without_link(self, mock_sleep, mock_parse):
+        """link 가 없는 항목은 스킵."""
+        mock_parse.return_value = _mock_feed_result([
+            {"title": "제목만", "summary": "요약"},
+            _feed_entry(title="정상 글", url="https://blog.test/ok"),
+        ])
+
+        feeds = (BlogFeed("테스트", "https://test.com/feed"),)
+        collector = TechBlogCollector(feeds=feeds, request_delay=0)
+        articles = collector.collect_all()
+
+        assert len(articles) == 1
+
+    @patch("collector.tech_blog.feedparser.parse")
+    @patch("collector.tech_blog.time.sleep")
+    def test_collect_all_skips_entries_without_summary(self, mock_sleep, mock_parse):
+        """요약이 없는 항목은 스킵."""
+        mock_parse.return_value = _mock_feed_result([
+            _feed_entry(title="요약 없음", url="https://blog.test/no-summary", summary=""),
+            _feed_entry(title="정상 글", url="https://blog.test/ok", summary="요약 있음"),
+        ])
+
+        feeds = (BlogFeed("테스트", "https://test.com/feed"),)
+        collector = TechBlogCollector(feeds=feeds, request_delay=0)
+        articles = collector.collect_all()
+
+        assert len(articles) == 1
+        assert articles[0].title == "정상 글"
+
+    @patch("collector.tech_blog.feedparser.parse")
+    @patch("collector.tech_blog.time.sleep")
+    def test_collect_all_handles_feed_error(self, mock_sleep, mock_parse):
+        """피드 파싱 예외 시 해당 피드를 스킵하고 계속 진행."""
+        mock_parse.side_effect = Exception("network error")
+
+        feeds = (BlogFeed("에러피드", "https://error.com/feed"),)
+        collector = TechBlogCollector(feeds=feeds, request_delay=0)
+        articles = collector.collect_all()
+
+        assert articles == []
+
+
+# ─────────────────────────────────────────────────────────
+# blog_collector Lambda 핸들러 테스트
+# ─────────────────────────────────────────────────────────
+
+
+class TestBlogCollectorHandler:
+    @patch("embedding.embed_text", return_value=[0.1] * 768)
+    @patch("app.S3Storage")
+    @patch("app.TechBlogCollector")
+    def test_saves_new_articles(self, mock_collector_cls, mock_storage_cls, mock_embed):
+        """신규 블로그 글이 S3 에 저장된다."""
+        import app
+
+        mock_storage = MagicMock()
+        mock_storage.get_all_urls.return_value = set()
+        mock_storage_cls.return_value = mock_storage
+
+        mock_collector = MagicMock()
+        mock_collector.collect_all.return_value = [_article()]
+        mock_collector_cls.return_value = mock_collector
+
+        result = app.blog_collector({}, None)
+
+        body = json.loads(result["body"])
+        assert body["saved"] == 1
+        assert body["skipped"] == 0
+        mock_storage.s3.put_object.assert_called_once()
+
+    @patch("embedding.embed_text", return_value=[0.1] * 768)
+    @patch("app.S3Storage")
+    @patch("app.TechBlogCollector")
+    def test_skips_existing_urls(self, mock_collector_cls, mock_storage_cls, mock_embed):
+        """이미 저장된 URL 은 스킵한다."""
+        import app
+
+        mock_storage = MagicMock()
+        mock_storage.get_all_urls.return_value = {"https://tech.kakao.com/post/123"}
+        mock_storage_cls.return_value = mock_storage
+
+        mock_collector = MagicMock()
+        mock_collector.collect_all.return_value = [_article()]
+        mock_collector_cls.return_value = mock_collector
+
+        result = app.blog_collector({}, None)
+
+        body = json.loads(result["body"])
+        assert body["saved"] == 0
+        assert body["skipped"] == 1
+        mock_storage.s3.put_object.assert_not_called()
+
+    @patch("embedding.embed_text", side_effect=RuntimeError("model error"))
+    @patch("app.S3Storage")
+    @patch("app.TechBlogCollector")
+    def test_saves_without_embedding_on_failure(
+        self, mock_collector_cls, mock_storage_cls, mock_embed,
+    ):
+        """임베딩 실패 시에도 임베딩 없이 S3 에 저장한다."""
+        import app
+
+        mock_storage = MagicMock()
+        mock_storage.get_all_urls.return_value = set()
+        mock_storage_cls.return_value = mock_storage
+
+        mock_collector = MagicMock()
+        mock_collector.collect_all.return_value = [_article()]
+        mock_collector_cls.return_value = mock_collector
+
+        result = app.blog_collector({}, None)
+
+        body = json.loads(result["body"])
+        assert body["saved"] == 1
+        mock_storage.s3.put_object.assert_called_once()
+        saved_body = json.loads(
+            mock_storage.s3.put_object.call_args.kwargs["Body"].decode("utf-8")
+        )
+        assert "embedding" not in saved_body


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#42

## #️⃣ 작업 내용

주요 IT 기업 23개의 기술 블로그 글을 수집하여 ChromaDB에 저장하는 파이프라인을 구축했습니다.
AI 서버가 유사도 검색으로 JD + 뉴스 + **기술 블로그**를 매칭하여 더 구체적인 면접 질문을 생성할 수 있습니다.

### 전체 흐름

```
EventBridge Cron (매일 20:00 UTC / 05:00 KST)
        |
        v
Lambda: blog_collector (컨테이너 이미지, VPC 밖)
        |
        |  1. S3 url-index.json에서 기존 저장된 URL 목록 로드
        |  2. 22개 RSS/Atom 피드 순회 (feedparser)
        |     - 20건 이하 피드: 전체 수집
        |     - 20건 초과 피드: 최근 2년 이내 글만 필터링
        |  3. RSS 요약 품질 판별 후 본문 추출
        |     - 요약이 완결된 글: RSS 요약 그대로 사용
        |     - 잘린 요약(... 으로 끝남) 또는 요약 없음: trafilatura로 원본 페이지 본문 추출 (피드당 최대 5건)
        |     - trafilatura 실패 시(카카오 등 SPA): BeautifulSoup으로 Nuxt.js JSON / article 영역 폴백 추출
        |     - 그것도 실패 시: 제목만 저장
        |  4. SK 데보션 HTML 크롤링
        |     - 목록 페이지에서 data-board-id로 글 ID 추출
        |     - 상세 페이지에서 DEVOTEE 요약(AI 자동 생성 요약) 추출
        |     - DEVOTEE 요약이 없는 글은 스킵
        |  5. 키워드 기반 직무 카테고리 태깅 (12개 직무)
        |  6. 기존 URL과 비교하여 신규 글만 후속 처리 (이미 저장된 URL은 임베딩/저장 스킵)
        |  7. 신규 글에 대해 KR-SBERT 임베딩 계산 후 S3에 JSON 저장
        |
        v
S3 -> EC2 Consumer -> ChromaDB (기존 파이프라인 공유, Consumer 변경 없음)
```

### 수집 대상 (23개)

| 방식 | 블로그 |
|------|--------|
| RSS (22개) | 네이버 D2, 카카오, 카카오페이, 카카오뱅크, 토스, 우아한형제들, 당근, 쿠팡, 라인, 삼성전자, LG U+, KT Cloud, NHN, 마켓컬리, 올리브영, 무신사, 뱅크샐러드, 야놀자, 쏘카, 넷마블, 지마켓, 11번가 |
| HTML 크롤링 (1개) | SK 데보션 (RSS 미제공, data-board-id + DEVOTEE 요약 추출) |

### 핵심 설계 결정 및 고민 과정

#### 1. RSS 요약 vs 본문 직접 파싱

처음에는 RSS의 description/summary 필드만 사용하려 했으나, **로컬에서 22개 피드를 실제로 파싱하여 데이터 품질을 확인**한 결과 블로그마다 품질 차이가 컸습니다.

**로컬 검증 결과 (블로그별 RSS 요약 상태)**

| 요약 상태 | 블로그 | 요약 길이 |
|-----------|--------|-----------|
| 본문 전체 포함 | 네이버 D2, 우아한형제들, 당근, 쿠팡, LG U+, KT Cloud, NHN, 무신사, 야놀자, 지마켓 | 3,000-23,000자 |
| 작성자 소개문 (짧지만 완결) | 카카오페이, 카카오뱅크, 토스, 삼성전자, 마켓컬리 | 21-253자 |
| 본문 앞부분 잘림 (서론/인사말만) | 카카오(258자), 라인(103자), 넷마블(221자) | 103-258자 |
| 요약 거의 없음 | 올리브영(1자), 뱅크샐러드(1자), 쏘카(0자) | 0-1자 |

- 당근/쿠팡 등 Medium 기반 블로그는 RSS에 본문 전체(16,000자 이상)가 포함되어 별도 처리 불필요
- 카카오/라인/넷마블은 "안녕하세요 OO팀입니다..." 수준의 서론만 포함 - 기술적 내용이 거의 없어 임베딩 의미 없음
- 올리브영/뱅크샐러드는 ... 1자만 있는 글이 섞여 있음
- 쏘카는 요약 필드가 아예 비어있음

<details>
<summary><b>작성자 소개문 유형 실제 데이터 예시 (클릭하여 펼치기)</b></summary>

짧지만 문장이 완결되어 있어 글의 핵심 주제와 키워드가 포함됩니다. 제목과 합치면 임베딩 매칭에 활용 가능한 수준입니다.

**카카오페이** (39-148자)
- "Sentry로 우아하게 프론트엔드 에러 추적하기" - 요약(70자): "Sentry를 통해 프론트엔드에서 발생하는 오류를 신속하게 탐지하고 정확한 원인을 파악하여 빠르게 대응하는 방법을 알아봅니다."
- "카카오페이 프론트엔드 개발자들이 React Query를 선택한 이유" - 요약(148자): "카카오페이 프론트엔드 개발자들이 React Query를 선택한 이유에 대해 설명합니다. 이 글은 연작 중 1편에 해당합니다..."

**카카오뱅크** (158-246자)
- "리액트의 현재와 미래, 그리고 AI: React Summit US 2025 참관기" - 요약(158자): "카카오뱅크 프론트엔드 클랜이 React Summit US 2025에 다녀왔습니다. 이 글에서는 현장에서 직접 확인한 AI 실무 엔지니어링, 리액트 거버넌스의 변화, 그리고 추상화 속 기본기의 중요성 등 프론트엔드 생태계의 가장 뜨거운 최신 기술 흐름을 현장의 열기와 함께 공유합니다."

**토스** (21-17,290자, 들쭉날쭉)
- "StarRocks 운영기: Resource Group으로 멀티테넌트 워크로드 격리하기" - 요약(33자): "서비스 쿼리가 밀리기 시작했을 때, 우리가 선택한 격리 전략"
- "토스플레이스 데이터봇 '판다(PANDA)'를 소개합니다" - 요약(21자): "질문 하나로 시작하는 데이터 문화 혁신"

**삼성전자** (129-236자)
- "AI-Native RAN: 기지국 최적화의 패러다임을 바꾸는 Network Foundation Model" - 요약(236자): "현대 이동통신 네트워크는 초고속, 초저지연을 지향하는 6G를 향해 급격히 진화하고 있습니다. 그러나 네트워크 고도화는 필연적으로 운영 복잡도의 폭발적 증가를 야기합니다. 삼성리서치는 이러한 난제를 해결하기 위해 AI를 RAN의 핵심부로 이식한 'AI for RAN' 기술을 선보였습니다..."

**마켓컬리** (52-100자)
- "현관문에도 얼굴이 있다: 배송 완료 사진 기반 On-device 오배송 탐지 시스템" - 요약(79자): "배송 완료 사진의 임베딩 유사도를 기반으로 오배송을 탐지하는 방법과, On-device 추론을 통해 서비스에 적용한 과정을 소개하는 글입니다."

</details>

**결론**: 잘린 요약(... 으로 끝나는 경우)을 자동 감지하여, trafilatura로 원본 페이지에서 본문을 추출합니다. trafilatura가 실패하면(카카오 등 SPA) BeautifulSoup으로 Nuxt.js JSON/article 영역을 폴백 추출합니다. 피드당 최대 5건까지만 본문 추출을 수행하여 Lambda 실행 시간을 제어합니다.

**본문 추출 로컬 검증 결과**

| 블로그 | 추출 방식 | 결과 |
|--------|-----------|------|
| 카카오 | BeautifulSoup (Nuxt.js JSON 파싱) | 5,103자 추출 성공 |
| 라인 | trafilatura | 9,966자 추출 성공 |
| 올리브영 | trafilatura | 7,779자 추출 성공 |
| 뱅크샐러드 | trafilatura | 3,733자 추출 성공 |
| 쏘카 | trafilatura | 12,353자 추출 성공 |
| 11번가 | trafilatura | 13,812자 추출 성공 |

#### 2. SK 데보션 처리

RSS를 제공하지 않아 HTML 크롤링이 필요했습니다. 로컬에서 목록/상세 페이지를 실제로 확인한 결과:

- 목록 페이지의 378자 설명: 본문 앞부분을 단순 truncate한 것 (모든 글이 정확히 378자로 일관) - 요약이 아님
- 상세 페이지에서 **DEVOTEE 요약** 발견: 데보션이 자체적으로 AI 요약을 붙여주는 기능 (3-5문장, 핵심 내용 포함)
- 10건 전부 DEVOTEE 요약이 존재하는 것을 확인

이 요약이 임베딩 품질에 더 적합하여, 상세 페이지에서 DEVOTEE 요약만 추출하는 방식을 채택했습니다. DEVOTEE 요약이 없는 글은 스킵합니다.

#### 3. 블로그 선별 과정

이슈에서 제시된 25개 후보를 로컬에서 실제 RSS 데이터를 확인하며 조정했습니다.

- **LG CNS 제거**: RSS 피드 응답은 오지만 항목이 0건 (피드 비활성 상태)
- **인프랩 제거**: 요약이 ... 1자만 있는 글 존재, 전반적으로 본문 truncate 품질 낮음 (47자)
- **데브시스터즈 제거**: 요약이 26-42자 수준으로 너무 짧아 임베딩 실효성 부족
- **올리브영/뱅크샐러드 복원**: 처음에 제거했다가, trafilatura 본문 추출로 해결 가능하여 재추가

#### 4. 직무 카테고리 태깅

블로그 글 내용을 분석하여 12개 직무 카테고리(백엔드, 프론트엔드, AI/ML 등)를 키워드 기반으로 자동 태깅합니다. raw_text 끝에 [직무] 섹션으로 추가하여 임베딩에 자연스럽게 반영됩니다. 3자 이하 영단어(AI, ML, AWS 등)는 단어 경계 정규식으로 오탐을 방지합니다. (예: "available"에서 "ai"가 매칭되지 않도록)

#### 5. 20건 초과 피드 필터링

RSS 피드가 제공하는 글 수는 블로그마다 다릅니다.

| 피드 글 수 | 블로그 |
|------------|--------|
| 10-20건 | 네이버 D2, 카카오, 토스, 우아한형제들, 당근, 쿠팡, LG U+, KT Cloud, NHN, 무신사, 야놀자, 쏘카, 넷마블, 지마켓, 11번가 |
| 50-84건 | 라인(50건), 카카오뱅크(54건), 삼성전자(84건), 뱅크샐러드(78건) |
| 100건 이상 | 카카오페이(158건), 마켓컬리(119건), 올리브영(186건) |

20건 이하 피드는 전체 수집하고, 20건 초과 피드는 보관 기간(2년)과 동일한 기간 필터를 적용하여 최근 2년 이내 글만 수집합니다. 이 필터 적용 시 총 약 569건이 수집됩니다.

#### 6. Lambda 배포 호환성

- feedparser/trafilatura는 Docker 전용 requirements-full.txt에만 포함하여 zip Lambda(JobListCollector) 250MB 제한에 영향 없음
- tech_blog 모듈은 blog_collector 핸들러 안에서 lazy import하여 다른 Lambda 핸들러의 cold start에 영향 없음
- trafilatura도 _fetch_page_content 내부에서 lazy import하여 모듈 로딩 시 무거운 의존성 지연

#### 7. 인코딩 처리

로컬 검증 중 라인/올리브영 등 일부 블로그가 HTTP 응답 헤더에서 ISO-8859-1로 인코딩을 선언하지만 실제로는 UTF-8인 경우를 발견했습니다. resp.apparent_encoding으로 자동 감지하도록 처리했습니다.

### 변경 파일

| 파일 | 변경 내용 |
|------|----------|
| `src/collector/tech_blog.py` | **신규** - 블로그 수집 모듈 (TechBlogCollector, BlogArticle, 본문 추출, 직무 분류) |
| `src/app.py` | blog_collector Lambda 핸들러 추가 |
| `src/requirements.txt` | 변경 없음 (zip Lambda 호환 유지) |
| `src/requirements-full.txt` | feedparser, trafilatura 추가 |
| `template.yaml` | BlogCollector Lambda + EventBridge(20:00 UTC) + Output 추가 |
| `tests/unit/test_tech_blog.py` | **신규** - 38개 단위 테스트 |

### 초기 데이터 축적 방법

EventBridge 스케줄은 Enabled: false로 설정했습니다. 첫 실행 시 569건 전체를 임베딩하면 Lambda 15분 타임아웃에 걸릴 수 있으므로:

1. develop 배포 후 AWS 콘솔에서 blog_collector Lambda 수동 호출
2. 타임아웃까지 처리된 건은 S3에 저장됨 - Consumer가 ChromaDB에 저장
3. 다시 수동 호출 - 이미 저장된 URL은 스킵하고 나머지를 이어서 처리
4. 전부 축적되면 Enabled: true로 변경하여 매일 자동 실행

이후 매일 실행 시에는 RSS 피드 파싱(수 초)만 수행하고, 신규 글(하루 5-10건)에 대해서만 임베딩/저장을 수행합니다.

## #️⃣ 테스트 결과

- 전체 **123개** 단위 테스트 통과, 회귀 없음
- 기술 블로그 관련 신규 테스트 **38개** (RSS 파싱, SK 데보션 크롤링, 본문 추출, 직무 분류, Lambda 핸들러 등)
- 22개 RSS 피드 실제 파싱 검증 완료 (각 피드별 요약 품질 직접 확인)
- SK 데보션 10건 DEVOTEE 요약 추출 검증 완료
- trafilatura 본문 추출 실제 검증: 카카오, 라인, 올리브영, 뱅크샐러드, 쏘카, 11번가

```
.venv/bin/python -m pytest tests/unit/ -q
123 passed in 0.88s
```

## #️⃣ 변경 사항 체크리스트

- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [x] 문서를 작성하거나 수정했나요? (필요한 경우)
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## 📎 참고 자료 (선택)

- 이슈: #42
- 뉴스 수집 PR (동일 패턴): #43, #44

