### PR TITLE
fix: blog_collector OOM 해결 — 수집/임베딩 Lambda 분리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -245,3 +245,4 @@ $RECYCLE.BIN/
 
 docs/
 CLAUDE.md
+.aws-sam/

--- a/src/app.py
+++ b/src/app.py
@@ -2,7 +2,7 @@
 
 EventBridge cron → [job_list_collector] → SQS → [job_detail_crawler] → S3 → EC2 consumer → ChromaDB
 EventBridge cron → [news_collector] → S3 → EC2 consumer → ChromaDB
-EventBridge cron → [blog_collector] → S3 → EC2 consumer → ChromaDB
+EventBridge cron → [blog_collector] → SQS → [blog_embedding] → S3 → EC2 consumer → ChromaDB
 """
 import json
 import logging
@@ -191,19 +191,20 @@ def news_collector(event, context):
 
 
 def blog_collector(event, context):
-    """주요 기업 기술 블로그 RSS 피드를 수집하여 S3 에 저장.
+    """주요 기업 기술 블로그 RSS 피드를 수집하여 신규 글을 SQS 로 전송.
 
-    피드별로 수집 → 임베딩 → 저장을 순차 처리하여 메모리를 절약한다.
+    임베딩은 별도 Lambda(blog_embedding)가 SQS 트리거로 1건씩 처리한다.
     """
     from collector.tech_blog import TechBlogCollector, blog_article_to_detail_dict  # noqa: C0415
-    from embedding import build_document, embed_text  # noqa: C0415
 
+    sqs = boto3.client("sqs")
+    queue_url = _required_env("BLOG_EMBEDDING_QUEUE_URL")
     storage = _make_storage()
     existing_urls = storage.get_all_urls()
 
     collector = TechBlogCollector()
 
-    saved = 0
+    new_data_list: list[dict] = []
     skipped = 0
 
     for feed in collector.feeds:
@@ -214,23 +215,7 @@ def blog_collector(event, context):
             if article.url in existing_urls:
                 skipped += 1
                 continue
-
-            data = blog_article_to_detail_dict(article)
-
-            try:
-                document = build_document(data["raw_text"], tuple(data["tech_stack"]))
-                embedding = embed_text(document)
-                data["embedding"] = embedding
-            except Exception:
-                logger.exception("임베딩 실패, 임베딩 없이 저장: id=%s", data["external_id"])
-
-            key = f"parsed/{data['source']}/{data['external_id']}.json"
-            storage.s3.put_object(
-                Bucket=storage.bucket,
-                Key=key,
-                Body=json.dumps(data, ensure_ascii=False).encode("utf-8"),
-            )
-            saved += 1
+            new_data_list.append(blog_article_to_detail_dict(article))
             existing_urls.add(article.url)
 
         del articles
@@ -242,11 +227,57 @@ def blog_collector(event, context):
         if article.url in existing_urls:
             skipped += 1
             continue
+        new_data_list.append(blog_article_to_detail_dict(article))
+        existing_urls.add(article.url)
 
-        data = blog_article_to_detail_dict(article)
+    del devocean_articles
+
+    new_count = _dispatch_blog_articles(sqs, queue_url, new_data_list)
+
+    logger.info("블로그 수집 완료: SQS 전송 %d건, 중복 스킵 %d건", new_count, skipped)
+    return {
+        "statusCode": 200,
+        "body": json.dumps({"new": new_count, "skipped": skipped}),
+    }
+
+
+def _dispatch_blog_articles(sqs, queue_url: str, data_list: list[dict]) -> int:
+    """블로그 글 dict 를 BlogEmbeddingQueue 로 배치 전송."""
+    batch: list[dict] = []
+
+    for data in data_list:
+        batch.append({
+            "Id": str(len(batch)),
+            "MessageBody": json.dumps(data, ensure_ascii=False),
+        })
+
+        if len(batch) == SQS_BATCH_SIZE:
+            sqs.send_message_batch(QueueUrl=queue_url, Entries=batch)
+            batch = []
+
+    if batch:
+        sqs.send_message_batch(QueueUrl=queue_url, Entries=batch)
+
+    return len(data_list)
+
+
+# ── Lambda 5: 블로그 임베딩 (SQS 트리거) ──
+
+
+def blog_embedding(event, context):
+    """SQS 트리거. 블로그 글 1건 임베딩 → S3 저장."""
+    from embedding import build_document, embed_text  # noqa: C0415
+
+    storage = _make_storage()
+
+    for record in event["Records"]:
+        data = json.loads(record["body"])
+        logger.info(
+            "블로그 임베딩: %s - %s", data["company_name"], data["title"],
+        )
 
         try:
-            document = build_document(data["raw_text"], tuple(data["tech_stack"]))
+            document = build_document(data["raw_text"], tuple(data.get("tech_stack", [])))
             embedding = embed_text(document)
             data["embedding"] = embedding
         except Exception:
@@ -258,16 +289,9 @@ def blog_collector(event, context):
             Key=key,
             Body=json.dumps(data, ensure_ascii=False).encode("utf-8"),
         )
-        saved += 1
-        existing_urls.add(article.url)
+        logger.info("S3 저장 완료: %s", key)
 
-    del devocean_articles
-
-    logger.info("블로그 수집 완료: 저장 %d건, 중복 스킵 %d건", saved, skipped)
-    return {
-        "statusCode": 200,
-        "body": json.dumps({"saved": saved, "skipped": skipped}),
-    }
+    return {"statusCode": 200}
 
 
 def _process_image_jd(image_detail: ImageJobDetail) -> JobDetail | None:

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,2 +1,4 @@
 requests
 beautifulsoup4
+feedparser
+trafilatura

--- a/template.yaml
+++ b/template.yaml
@@ -166,17 +166,57 @@ Resources:
       DockerContext: .
       Dockerfile: src/Dockerfile
 
+  # ── SQS: 블로그 임베딩 큐 ──
+  BlogEmbeddingQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: passroute-blog-embedding-queue
+      VisibilityTimeout: 360
+      MessageRetentionPeriod: 86400
+      RedrivePolicy:
+        deadLetterTargetArn: !GetAtt BlogEmbeddingDLQ.Arn
+        maxReceiveCount: 3
+
+  BlogEmbeddingDLQ:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: passroute-blog-embedding-dlq
+      MessageRetentionPeriod: 604800
+
+  BlogEmbeddingDLQAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: passroute-blog-embedding-dlq-has-messages
+      AlarmDescription: passroute blog embedding DLQ에 메시지가 쌓여 있음
+      Namespace: AWS/SQS
+      MetricName: ApproximateNumberOfMessagesVisible
+      Dimensions:
+        - Name: QueueName
+          Value: !GetAtt BlogEmbeddingDLQ.QueueName
+      Statistic: Maximum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 0
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+      AlarmActions:
+        - !Ref DLQAlarmTopic
+
   # ── Lambda 4: 기술 블로그 수집 (cron) ──
   BlogCollector:
     Type: AWS::Serverless::Function
     Properties:
-      PackageType: Image
+      Runtime: python3.11
+      CodeUri: src/
+      Handler: app.blog_collector
       Timeout: 900
-      MemorySize: 1536
-      ImageConfig:
-        Command:
-          - app.blog_collector
+      MemorySize: 512
+      Environment:
+        Variables:
+          BLOG_EMBEDDING_QUEUE_URL: !Ref BlogEmbeddingQueue
       Policies:
+        - SQSSendMessagePolicy:
+            QueueName: !GetAtt BlogEmbeddingQueue.QueueName
         - S3CrudPolicy:
             BucketName: !Ref CrawlerDataBucket
       Events:
@@ -184,7 +224,27 @@ Resources:
           Type: Schedule
           Properties:
             Schedule: cron(0 20 * * ? *)
-            Enabled: false
+            Enabled: true
+
+  # ── Lambda 5: 블로그 임베딩 (SQS 트리거) ──
+  BlogEmbedding:
+    Type: AWS::Serverless::Function
+    Properties:
+      PackageType: Image
+      Timeout: 120
+      MemorySize: 1536
+      ImageConfig:
+        Command:
+          - app.blog_embedding
+      Policies:
+        - S3CrudPolicy:
+            BucketName: !Ref CrawlerDataBucket
+      Events:
+        SQSTrigger:
+          Type: SQS
+          Properties:
+            Queue: !GetAtt BlogEmbeddingQueue.Arn
+            BatchSize: 1
     Metadata:
       DockerTag: python3.11
       DockerContext: .
@@ -233,6 +293,12 @@ Outputs:
   BlogCollectorArn:
     Description: 블로그 수집 Lambda ARN
     Value: !GetAtt BlogCollector.Arn
+  BlogEmbeddingArn:
+    Description: 블로그 임베딩 Lambda ARN
+    Value: !GetAtt BlogEmbedding.Arn
+  BlogEmbeddingQueueUrl:
+    Description: 블로그 임베딩 SQS Queue URL
+    Value: !Ref BlogEmbeddingQueue
   DLQAlarmTopicArn:
     Description: DLQ 알람 SNS 토픽 ARN
     Value: !Ref DLQAlarmTopic

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,3 +22,4 @@ def _set_required_env(monkeypatch):
     """app._required_env 가 던지지 않도록 모든 테스트에 더미 값을 주입."""
     monkeypatch.setenv("S3_BUCKET", "test-bucket")
     monkeypatch.setenv("JOB_DETAIL_QUEUE_URL", "https://sqs.test/detail")
+    monkeypatch.setenv("BLOG_EMBEDDING_QUEUE_URL", "https://sqs.test/blog-embedding")

--- a/tests/unit/test_tech_blog.py
+++ b/tests/unit/test_tech_blog.py
@@ -397,16 +397,21 @@ class TestDevocean:
 
 
 class TestBlogCollectorHandler:
-    @patch("embedding.embed_text", return_value=[0.1] * 768)
+    @patch("app.boto3")
     @patch("app.S3Storage")
     @patch("collector.tech_blog.TechBlogCollector")
-    def test_saves_new_articles(self, mock_collector_cls, mock_storage_cls, mock_embed):
-        """신규 블로그 글이 S3 에 저장된다."""
+    def test_dispatches_new_articles_to_sqs(
+        self, mock_collector_cls, mock_storage_cls, mock_boto3,
+    ):
+        """신규 블로그 글이 SQS 로 전송된다."""
         import app
 
         mock_storage = MagicMock()
         mock_storage.get_all_urls.return_value = set()
         mock_storage_cls.return_value = mock_storage
+
+        mock_sqs = MagicMock()
+        mock_boto3.client.return_value = mock_sqs
 
         mock_feed = MagicMock()
         mock_collector = MagicMock()
@@ -418,21 +423,29 @@ class TestBlogCollectorHandler:
         result = app.blog_collector({}, None)
 
         body = json.loads(result["body"])
-        assert body["saved"] == 1
+        assert body["new"] == 1
         assert body["skipped"] == 0
-        mock_storage.s3.put_object.assert_called_once()
+        mock_sqs.send_message_batch.assert_called_once()
 
-    @patch("embedding.embed_text", return_value=[0.1] * 768)
+        sent_entry = mock_sqs.send_message_batch.call_args.kwargs["Entries"][0]
+        sent_data = json.loads(sent_entry["MessageBody"])
+        assert sent_data["source"] == "tech_blog"
+        assert sent_data["company_name"] == "카카오"
+
+    @patch("app.boto3")
     @patch("app.S3Storage")
     @patch("collector.tech_blog.TechBlogCollector")
-    def test_skips_existing_urls(self, mock_collector_cls, mock_storage_cls, mock_embed):
-        """이미 저장된 URL 은 스킵한다."""
+    def test_skips_existing_urls(self, mock_collector_cls, mock_storage_cls, mock_boto3):
+        """이미 저장된 URL 은 스킵하고 SQS 전송하지 않는다."""
         import app
 
         mock_storage = MagicMock()
         mock_storage.get_all_urls.return_value = {"https://tech.kakao.com/post/123"}
         mock_storage_cls.return_value = mock_storage
 
+        mock_sqs = MagicMock()
+        mock_boto3.client.return_value = mock_sqs
+
         mock_feed = MagicMock()
         mock_collector = MagicMock()
         mock_collector.feeds = [mock_feed]
@@ -443,36 +456,62 @@ class TestBlogCollectorHandler:
         result = app.blog_collector({}, None)
 
         body = json.loads(result["body"])
-        assert body["saved"] == 0
+        assert body["new"] == 0
         assert body["skipped"] == 1
-        mock_storage.s3.put_object.assert_not_called()
+        mock_sqs.send_message_batch.assert_not_called()
+
+
+# ─────────────────────────────────────────────────────────
+# blog_embedding Lambda 핸들러 테스트
+# ─────────────────────────────────────────────────────────
+
+
+def _make_blog_sqs_event(data: dict) -> dict:
+    return {"Records": [{"body": json.dumps(data)}]}
+
+
+class TestBlogEmbeddingHandler:
+    @patch("embedding.embed_text", return_value=[0.1] * 768)
+    @patch("app.S3Storage")
+    def test_embeds_and_saves_to_s3(self, mock_storage_cls, mock_embed):
+        """블로그 글 1건을 임베딩하여 S3 에 저장한다."""
+        import app
+
+        mock_storage = MagicMock()
+        mock_storage_cls.return_value = mock_storage
+
+        data = blog_article_to_detail_dict(_article())
+        event = _make_blog_sqs_event(data)
+
+        result = app.blog_embedding(event, None)
+
+        assert result["statusCode"] == 200
+        mock_storage.s3.put_object.assert_called_once()
+
+        saved_body = json.loads(
+            mock_storage.s3.put_object.call_args.kwargs["Body"].decode("utf-8"),
+        )
+        assert saved_body["embedding"] == [0.1] * 768
+        assert saved_body["source"] == "tech_blog"
 
     @patch("embedding.embed_text", side_effect=RuntimeError("model error"))
     @patch("app.S3Storage")
-    @patch("collector.tech_blog.TechBlogCollector")
-    def test_saves_without_embedding_on_failure(
-        self, mock_collector_cls, mock_storage_cls, mock_embed,
-    ):
+    def test_saves_without_embedding_on_failure(self, mock_storage_cls, mock_embed):
         """임베딩 실패 시에도 임베딩 없이 S3 에 저장한다."""
         import app
 
         mock_storage = MagicMock()
-        mock_storage.get_all_urls.return_value = set()
         mock_storage_cls.return_value = mock_storage
 
-        mock_feed = MagicMock()
-        mock_collector = MagicMock()
-        mock_collector.feeds = [mock_feed]
-        mock_collector._fetch_feed.return_value = [_article()]
-        mock_collector._fetch_devocean.return_value = []
-        mock_collector_cls.return_value = mock_collector
+        data = blog_article_to_detail_dict(_article())
+        event = _make_blog_sqs_event(data)
 
-        result = app.blog_collector({}, None)
+        result = app.blog_embedding(event, None)
 
-        body = json.loads(result["body"])
-        assert body["saved"] == 1
+        assert result["statusCode"] == 200
         mock_storage.s3.put_object.assert_called_once()
+
         saved_body = json.loads(
-            mock_storage.s3.put_object.call_args.kwargs["Body"].decode("utf-8")
+            mock_storage.s3.put_object.call_args.kwargs["Body"].decode("utf-8"),
         )
         assert "embedding" not in saved_body


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#49

## #️⃣ 작업 내용

### 문제

`blog_collector` Lambda(1536MB)가 수집 라이브러리(trafilatura, feedparser 등)와 임베딩 라이브러리(ONNX runtime, numpy, transformers)를 **하나의 Lambda에서 동시에 로드**하여 반복적으로 OOM 발생.

CloudWatch 로그 기준 `maxMemoryUsedMB: 1536`으로 메모리를 전부 사용한 뒤 약 70초 시점에 kill.

### 시도했던 접근과 한계

| 접근 | 한계 |
|------|------|
| 메모리 증가 (1536 → 2048MB) | 임시 조치. 라이브러리 추가 시 재발 가능하고, 비용 증가 |
| Phase 분리 (수집 후 gc.collect → 임베딩) | Python이 C 확장(ONNX, numpy) 메모리를 OS에 반환하지 않아 불안정 |

### 해결: Lambda 분리 (JD 파이프라인 패턴 적용)

JD 파이프라인(`job_list_collector` → SQS → `job_detail_crawler`)에서 이미 검증된 수집/임베딩 분리 패턴을 블로그 파이프라인에도 적용.

**변경 전:**
```
blog_collector (Image, 1536MB)
  → 22개 RSS 수집 + 임베딩 + S3 저장 (OOM 발생)
```

**변경 후:**
```
blog_collector (Zip, 512MB) ─── 수집 전용
  → 22개 RSS + 데보션 수집
  → 중복 URL 필터링
  → 신규 글을 SQS 전송 (batch 10)

BlogEmbeddingQueue (SQS)
  → batch size 1, visibility 360s, DLQ 3회

blog_embedding (Image, 1536MB) ─── 임베딩 전용
  → SQS에서 1건 수신
  → build_document + embed_text
  → S3 저장
```

### 이 방식을 선택한 이유

- **OOM이 구조적으로 불가능**: blog_collector에서 ONNX/numpy/transformers가 완전히 제거되고, blog_embedding은 1건 단위 처리라 메모리 누적 없음
- **검증된 패턴**: JD 파이프라인에서 동일한 구조로 이미 안정 운영 중
- **blog_collector 경량화**: Docker Image → Zip 전환으로 콜드 스타트 개선, 메모리 1536 → 512MB로 절감
- **장애 격리**: 블로그 전용 SQS + DLQ로 JD 파이프라인과 독립적으로 모니터링/재처리 가능
- **기존 하류 파이프라인 변경 없음**: S3 저장 형식이 동일하므로 Consumer/ChromaDB 수정 불필요

### 변경 파일 요약

| 파일 | 변경 |
|------|------|
| `src/app.py` | blog_collector에서 임베딩 제거 + SQS 전송, blog_embedding 핸들러 추가 |
| `template.yaml` | BlogCollector Image→Zip(512MB), BlogEmbeddingQueue/DLQ/Alarm, BlogEmbedding Lambda |
| `src/requirements.txt` | feedparser, trafilatura 추가 (Zip 패키징용) |
| `tests/unit/test_tech_blog.py` | SQS 전송 테스트로 변경, TestBlogEmbeddingHandler 추가 |
| `tests/conftest.py` | BLOG_EMBEDDING_QUEUE_URL 환경변수 추가 |

## #️⃣ 테스트 결과

- 124개 단위 테스트 전체 통과
- TestBlogCollectorHandler: SQS 배치 전송 검증 (신규 글 전송, 중복 URL 스킵)
- TestBlogEmbeddingHandler: SQS 이벤트 수신 → 임베딩 → S3 저장 검증, 임베딩 실패 시 graceful degradation 검증

## #️⃣ 변경 사항 체크리스트

- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## #️⃣ 리뷰 요구사항 (선택)

- `template.yaml`에서 BlogCollector가 Image → Zip으로 전환되는데, CloudFormation이 기존 Lambda를 replacement 처리할 수 있습니다. FunctionName이 미지정이라 자동 처리되지만, 배포 시 EventBridge 스케줄 재연결이 정상적인지 확인 필요.
- `src/requirements.txt`에 feedparser, trafilatura를 추가하여 JobListCollector 등 다른 Zip Lambda에도 불필요한 의존성이 포함됩니다. 패키지 크기가 250MB 미만이면 문제없지만, 향후 분리가 필요할 수 있습니다.