### PR TITLE
fix: Discord 웹훅 DLQ 알림 403 해결

### DIFF
--- a/src/notify.py
+++ b/src/notify.py
@@ -49,7 +49,10 @@ def discord_notifier(event, _context):
         req = urllib.request.Request(
             webhook_url,
             data=data,
-            headers={"Content-Type": "application/json"},
+            headers={
+                "Content-Type": "application/json",
+                "User-Agent": "passroute-dlq-notifier/1.0",
+            },
             method="POST",
         )
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#51

## #️⃣ 작업 내용

DLQ에 메시지가 쌓여 CloudWatch 알람이 발동되면 SNS → `DLQDiscordNotifier` Lambda → Discord 웹훅으로 알림이 전송되어야 하는데, Discord API가 HTTP 403을 반환하여 알림이 오지 않던 문제 수정.

### 원인

`notify.py`에서 `urllib.request.Request`에 `User-Agent` 헤더를 설정하지 않아 Python 기본값(`Python-urllib/3.11`)이 사용됨. Discord가 AWS Lambda IP 대역에서 오는 이 User-Agent를 차단.

동일한 웹훅 URL로 로컬 curl(기본 User-Agent: `curl/x.x`)은 정상(HTTP 204)이었으나, Lambda에서만 403이 발생한 이유.

### 수정

`src/notify.py`의 요청 헤더에 `User-Agent: passroute-dlq-notifier/1.0` 추가.

## #️⃣ 테스트 결과

- 124개 단위 테스트 전체 통과
- 배포 후 Lambda 수동 호출로 Discord 알림 수신 확인 필요

## #️⃣ 변경 사항 체크리스트

- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?